### PR TITLE
[RHPAM-731] Persist business central monitoring controller configuration

### DIFF
--- a/templates/rhpam70-prod-immutable-monitor.yaml
+++ b/templates/rhpam70-prod-immutable-monitor.yaml
@@ -327,6 +327,8 @@ objects:
           - name: businesscentral-keystore-volume
             mountPath: "/etc/businesscentral-secret-volume"
             readOnly: true
+          - name: "${APPLICATION_NAME}-rhpamcentr-pvol"
+            mountPath: "/opt/eap/standalone/data/bpmsuite"
           livenessProbe:
             exec:
               command:
@@ -406,6 +408,9 @@ objects:
         - name: businesscentral-keystore-volume
           secret:
             secretName: "${BUSINESS_CENTRAL_HTTPS_SECRET}"
+        - name: "${APPLICATION_NAME}-rhpamcentr-pvol"
+          persistentVolumeClaim:
+            claimName: "${APPLICATION_NAME}-rhpamcentr-claim"
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:
@@ -484,6 +489,18 @@ objects:
   kind: PersistentVolumeClaim
   metadata:
     name: "${APPLICATION_NAME}-smartrouter-claim"
+    labels:
+      application: "${APPLICATION_NAME}"
+  spec:
+    accessModes:
+    - ReadWriteMany
+    resources:
+      requests:
+        storage: "64Mi"
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${APPLICATION_NAME}-rhpamcentr-claim"
     labels:
       application: "${APPLICATION_NAME}"
   spec:

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -535,6 +535,8 @@ objects:
           - name: businesscentral-keystore-volume
             mountPath: "/etc/businesscentral-secret-volume"
             readOnly: true
+          - name: "${APPLICATION_NAME}-rhpamcentr-pvol"
+            mountPath: "/opt/eap/standalone/data/bpmsuite"
           livenessProbe:
             exec:
               command:
@@ -596,6 +598,9 @@ objects:
         - name: businesscentral-keystore-volume
           secret:
             secretName: "${BUSINESS_CENTRAL_HTTPS_SECRET}"
+        - name: "${APPLICATION_NAME}-rhpamcentr-pvol"
+          persistentVolumeClaim:
+            claimName: "${APPLICATION_NAME}-rhpamcentr-claim"
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:
@@ -1094,7 +1099,19 @@ objects:
       application: "${APPLICATION_NAME}"
   spec:
     accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: "64Mi"
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: "${APPLICATION_NAME}-rhpamcentr-claim"
+    labels:
+      application: "${APPLICATION_NAME}"
+  spec:
+    accessModes:
+    - ReadWriteOnce
     resources:
       requests:
         storage: "64Mi"


### PR DESCRIPTION
When using Business Central Monitoring, there is no authoring and no data to be persisted. However, the controller configuration must persist to not disconnect from KIE servers on a pod restart.

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
