### PR TITLE
[RHPAM-181] - Kie server timers aren't clustered

### DIFF
--- a/templates/rhpam70-kieserver-postgresql.yaml
+++ b/templates/rhpam70-kieserver-postgresql.yaml
@@ -159,6 +159,11 @@ parameters:
   name: KIE_SERVER_POSTGRESQL_DB
   value: rhpam7
   required: false
+- displayName: PostgreSQL Database max prepared connections
+  description: Allows the PostgreSQL to handle XA transactions.
+  name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+  value: '100'
+  required: true
 - displayName: Drools Server Filter Classes
   description: KIE execution server class filtering (Sets the org.drools.server.filter.classes system property)
   name: DROOLS_SERVER_FILTER_CLASSES
@@ -552,6 +557,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:

--- a/templates/rhpam70-prod-immutable-kieserver.yaml
+++ b/templates/rhpam70-prod-immutable-kieserver.yaml
@@ -128,6 +128,11 @@ parameters:
   name: KIE_SERVER_POSTGRESQL_DB
   value: rhpam7
   required: false
+- displayName: PostgreSQL Database max prepared connections
+  description: Allows the PostgreSQL to handle XA transactions.
+  name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+  value: '100'
+  required: true
 - displayName: Drools Server Filter Classes
   description: KIE execution server class filtering (Sets the org.drools.server.filter.classes system property)
   name: DROOLS_SERVER_FILTER_CLASSES
@@ -608,6 +613,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:

--- a/templates/rhpam70-prod.yaml
+++ b/templates/rhpam70-prod.yaml
@@ -141,6 +141,11 @@ parameters:
   name: KIE_SERVER_POSTGRESQL_DB
   value: rhpam7
   required: false
+- displayName: PostgreSQL Database max prepared connections
+  description: Allows the PostgreSQL to handle XA transactions.
+  name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+  value: '100'
+  required: true
 - displayName: Drools Server Filter Classes
   description: KIE execution server class filtering (Sets the org.drools.server.filter.classes system property)
   name: DROOLS_SERVER_FILTER_CLASSES
@@ -993,6 +998,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:
@@ -1213,6 +1220,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -144,6 +144,11 @@ parameters:
   name: KIE_SERVER_POSTGRESQL_DB
   value: rhpam7
   required: false
+- displayName: PostgreSQL Database max prepared connections
+  description: Allows the PostgreSQL to handle XA transactions.
+  name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+  value: '100'
+  required: true
 - displayName: Drools Server Filter Classes
   description: KIE execution server class filtering (Sets the org.drools.server.filter.classes system property)
   name: DROOLS_SERVER_FILTER_CLASSES
@@ -994,6 +999,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:
@@ -1212,6 +1219,8 @@ objects:
             value: "${KIE_SERVER_POSTGRESQL_PWD}"
           - name: POSTGRESQL_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
+          - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+            value: "${POSTGRESQL_MAX_PREPARED_TRANSACTIONS}"
         volumes:
         - name: "${APPLICATION_NAME}-postgresql-pvol"
           persistentVolumeClaim:


### PR DESCRIPTION
Include the POSTGRESQL_MAX_PREPARED_TRANSACTIONS env on the templates that uses POstgreSQL server.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
