### PR TITLE
[RHPAM-1173] rhpam70-dev branch should use CE sprint-18

### DIFF
--- a/businesscentral-indexing/image.yaml
+++ b/businesscentral-indexing/image.yaml
@@ -47,7 +47,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -135,7 +135,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -141,7 +141,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -120,7 +120,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -209,7 +209,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -63,7 +63,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master


### PR DESCRIPTION
[RHPAM-1173] rhpam70-dev branch should use CE sprint-18
https://issues.jboss.org/browse/RHPAM-1173

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
