### PR TITLE
[RHPAM-1178] EJB Timer Datasource only works for MySQL with default port

### DIFF
--- a/templates/rhpam70-kieserver-externaldb.yaml
+++ b/templates/rhpam70-kieserver-externaldb.yaml
@@ -168,6 +168,10 @@ parameters:
   description: KIE execution server external database host, for ejb_timer datasource configuration
   name: KIE_SERVER_EXTERNALDB_HOST
   required: true
+- displayName: KIE Server External Database Port
+  description: KIE execution server external database port, for ejb_timer datasource configuration
+  name: KIE_SERVER_EXTERNALDB_PORT
+  required: true
 - displayName: KIE Server External Database name
   description: KIE execution server external database name, for ejb_timer datasource configuration
   name: KIE_SERVER_EXTERNALDB_DB
@@ -470,6 +474,8 @@ objects:
             value: "${KIE_SERVER_EXTERNALDB_URL}"
           - name: RHPAM_SERVICE_HOST
             value: "${KIE_SERVER_EXTERNALDB_HOST}"
+          - name: RHPAM_SERVICE_PORT
+            value: "${KIE_SERVER_EXTERNALDB_PORT}"
           - name: RHPAM_DATABASE
             value: "${KIE_SERVER_EXTERNALDB_DB}"
 ## External database driver settings END


### PR DESCRIPTION
Added parameter to allow configuration of database port

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
