### PR TITLE
[RHPAM-1119] set router listening port static

### DIFF
--- a/templates/docs/rhpam70-prod-immutable-monitor.adoc
+++ b/templates/docs/rhpam70-prod-immutable-monitor.adoc
@@ -237,7 +237,6 @@ for more information.
 |`HOSTNAME_HTTPS` | Custom hostname for https service route.  Leave blank for default hostname, e.g.: secure-<application-name>-rhpamcentrmon-<project>.<default-domain-suffix> | `${BUSINESS_CENTRAL_HOSTNAME_HTTPS}`
 .11+| `${APPLICATION_NAME}-smartrouter`
 |`KIE_SERVER_ROUTER_HOST` | -- | --
-|`KIE_SERVER_ROUTER_PORT` | Port in which the smart router server listens (router property org.kie.server.router.port) | `${KIE_SERVER_ROUTER_PORT}`
 |`KIE_SERVER_ROUTER_URL_EXTERNAL` | Public URL where the router can be found. Format http://<host>:<port>  (router property org.kie.server.router.url.external) | `${KIE_SERVER_ROUTER_URL_EXTERNAL}`
 |`KIE_SERVER_ROUTER_ID` | Router ID used when connecting to the controller (router property org.kie.server.router.id) | `${KIE_SERVER_ROUTER_ID}`
 |`KIE_SERVER_ROUTER_NAME` | Router name used when connecting to the controller (router property org.kie.server.router.name) | `${KIE_SERVER_ROUTER_NAME}`

--- a/templates/docs/rhpam70-prod.adoc
+++ b/templates/docs/rhpam70-prod.adoc
@@ -36,7 +36,6 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`IMAGE_STREAM_TAG` | -- | A named pointer to an image in an image stream. Default is "1.0". | 1.0 | False
 |`SMART_ROUTER_HOSTNAME_HTTP` | `HOSTNAME_HTTP` | Custom hostname for http service route.  Leave blank for default hostname, e.g. <application-name>-smartrouter-<project>.<default-domain-suffix>' | `${BUSINESS_CENTRAL_HOSTNAME_HTTP}` | False
 |`KIE_SERVER_ROUTER_ID` | `KIE_SERVER_ROUTER_ID` | Router ID used when connecting to the controller (router property org.kie.server.router.id) | kie-server-router | ?
-|`KIE_SERVER_ROUTER_PORT` | `KIE_SERVER_ROUTER_PORT` | Port in which the smart router server listens (router property org.kie.server.router.port) | `${KIE_SERVER_ROUTER_PORT}` | False
 |`KIE_SERVER_ROUTER_PROTOCOL` | `KIE_SERVER_ROUTER_PROTOCOL` | KIE server router protocol (Used to build the org.kie.server.router.url.external property) | `${KIE_SERVER_ROUTER_PROTOCOL}` | False
 |`KIE_SERVER_ROUTER_URL_EXTERNAL` | `KIE_SERVER_ROUTER_URL_EXTERNAL` | Public URL where the router can be found. Format http://<host>:<port>  (router property org.kie.server.router.url.external) | `${KIE_SERVER_ROUTER_URL_EXTERNAL}` | ?
 |`KIE_SERVER_ROUTER_NAME` | `KIE_SERVER_ROUTER_NAME` | Router name used when connecting to the controller (router property org.kie.server.router.name) | KIE Server Router | ?

--- a/templates/docs/rhpam70-sit.adoc
+++ b/templates/docs/rhpam70-sit.adoc
@@ -412,7 +412,6 @@ for more information.
 |`MAVEN_REPO_USERNAME` | Username to access the Maven repository. | `${MAVEN_REPO_USERNAME}`
 |`MAVEN_REPO_PASSWORD` | Password to access the Maven repository. | `${MAVEN_REPO_PASSWORD}`
 |`KIE_SERVER_ROUTER_SERVICE` | -- | `${APPLICATION_NAME}-smartrouter`
-|`KIE_SERVER_ROUTER_PORT` | Port in which the smart router server listens (router property org.kie.server.router.port) | `${KIE_SERVER_ROUTER_PORT}`
 |`KIE_SERVER_ROUTER_PROTOCOL` | KIE server router protocol (Used to build the org.kie.server.router.url.external property) | `${KIE_SERVER_ROUTER_PROTOCOL}`
 |`KIE_SERVER_PERSISTENCE_DS` | KIE execution server persistence datasource (Sets the org.kie.server.persistence.ds system property) | `${KIE_SERVER_PERSISTENCE_DS}`
 |`DATASOURCES` | -- | `RHPAM`

--- a/templates/rhpam70-prod-immutable-monitor.yaml
+++ b/templates/rhpam70-prod-immutable-monitor.yaml
@@ -89,11 +89,6 @@ parameters:
   description: Router ID used when connecting to the controller (router property org.kie.server.router.id)
   name: KIE_SERVER_ROUTER_ID
   value: kie-server-router
-- displayName: Smart Router listening port
-  description: Port in which the smart router server listens (router property org.kie.server.router.port)
-  name: KIE_SERVER_ROUTER_PORT
-  value: "9000"
-  required: false
 - displayName: Smart Router protocol
   description: KIE server router protocol (Used to build the org.kie.server.router.url.external property)
   name: KIE_SERVER_ROUTER_PROTOCOL
@@ -248,8 +243,8 @@ objects:
   apiVersion: v1
   spec:
     ports:
-    - port: ${{KIE_SERVER_ROUTER_PORT}}
-      targetPort: ${{KIE_SERVER_ROUTER_PORT}}
+    - port: 9000
+      targetPort: 9000
     selector:
       deploymentConfig: "${APPLICATION_NAME}-smartrouter"
   metadata:
@@ -497,7 +492,7 @@ objects:
               memory: "${SMART_ROUTER_MEMORY_LIMIT}"
           ports:
           - name: http
-            containerPort: ${{KIE_SERVER_ROUTER_PORT}}
+            containerPort: 9000
             protocol: TCP
           env:
           - name: KIE_SERVER_ROUTER_HOST
@@ -505,7 +500,7 @@ objects:
               fieldRef:
                 fieldPath: status.podIP
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_URL_EXTERNAL
             value: "${KIE_SERVER_ROUTER_URL_EXTERNAL}"
           - name: KIE_SERVER_ROUTER_ID

--- a/templates/rhpam70-prod.yaml
+++ b/templates/rhpam70-prod.yaml
@@ -88,11 +88,6 @@ parameters:
   description: Router ID used when connecting to the controller (router property org.kie.server.router.id)
   name: KIE_SERVER_ROUTER_ID
   value: kie-server-router
-- displayName: Smart Router listening port
-  description: Port in which the smart router server listens (router property org.kie.server.router.port)
-  name: KIE_SERVER_ROUTER_PORT
-  value: "9000"
-  required: false
 - displayName: Smart Router protocol
   description: KIE server router protocol (Used to build the org.kie.server.router.url.external property)
   name: KIE_SERVER_ROUTER_PROTOCOL
@@ -355,8 +350,8 @@ objects:
   apiVersion: v1
   spec:
     ports:
-    - port: ${{KIE_SERVER_ROUTER_PORT}}
-      targetPort: ${{KIE_SERVER_ROUTER_PORT}}
+    - port: 9000
+      targetPort: 9000
     selector:
       deploymentConfig: "${APPLICATION_NAME}-smartrouter"
   metadata:
@@ -787,7 +782,7 @@ objects:
               memory: "${SMART_ROUTER_MEMORY_LIMIT}"
           ports:
           - name: http
-            containerPort: ${{KIE_SERVER_ROUTER_PORT}}
+            containerPort: 9000
             protocol: TCP
           env:
           - name: KIE_SERVER_ROUTER_HOST
@@ -795,7 +790,7 @@ objects:
               fieldRef:
                 fieldPath: status.podIP
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_URL_EXTERNAL
             value: "${KIE_SERVER_ROUTER_URL_EXTERNAL}"
           - name: KIE_SERVER_ROUTER_ID
@@ -937,7 +932,7 @@ objects:
           - name: KIE_SERVER_ROUTER_SERVICE
             value: "${APPLICATION_NAME}-smartrouter"
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_PROTOCOL
             value: "${KIE_SERVER_ROUTER_PROTOCOL}"
           - name: KIE_SERVER_PERSISTENCE_DS
@@ -1183,7 +1178,7 @@ objects:
           - name: KIE_SERVER_ROUTER_SERVICE
             value: "${APPLICATION_NAME}-smartrouter"
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_PROTOCOL
             value: "${KIE_SERVER_ROUTER_PROTOCOL}"
           - name: KIE_SERVER_PERSISTENCE_DS

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -88,11 +88,6 @@ parameters:
   description: Router ID used when connecting to the controller (router property org.kie.server.router.id)
   name: KIE_SERVER_ROUTER_ID
   value: kie-server-router
-- displayName: Smart Router listening port
-  description: Port in which the smart router server listens (router property org.kie.server.router.port)
-  name: KIE_SERVER_ROUTER_PORT
-  value: "9000"
-  required: false
 - displayName: Smart Router protocol
   description: KIE server router protocol (Used to build the org.kie.server.router.url.external property)
   name: KIE_SERVER_ROUTER_PROTOCOL
@@ -355,8 +350,8 @@ objects:
   apiVersion: v1
   spec:
     ports:
-    - port: ${{KIE_SERVER_ROUTER_PORT}}
-      targetPort: ${{KIE_SERVER_ROUTER_PORT}}
+    - port: 9000
+      targetPort: 9000
     selector:
       deploymentConfig: "${APPLICATION_NAME}-smartrouter"
   metadata:
@@ -786,7 +781,7 @@ objects:
               memory: "${SMART_ROUTER_MEMORY_LIMIT}"
           ports:
           - name: http
-            containerPort: ${{KIE_SERVER_ROUTER_PORT}}
+            containerPort: 9000
             protocol: TCP
           env:
           - name: KIE_SERVER_ROUTER_HOST
@@ -794,7 +789,7 @@ objects:
               fieldRef:
                 fieldPath: status.podIP
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_URL_EXTERNAL
             value: "${KIE_SERVER_ROUTER_URL_EXTERNAL}"
           - name: KIE_SERVER_ROUTER_ID
@@ -936,7 +931,7 @@ objects:
           - name: KIE_SERVER_ROUTER_SERVICE
             value: "${APPLICATION_NAME}-smartrouter"
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_PROTOCOL
             value: "${KIE_SERVER_ROUTER_PROTOCOL}"
           - name: KIE_SERVER_PERSISTENCE_DS
@@ -1182,7 +1177,7 @@ objects:
           - name: KIE_SERVER_ROUTER_SERVICE
             value: "${APPLICATION_NAME}-smartrouter"
           - name: KIE_SERVER_ROUTER_PORT
-            value: "${KIE_SERVER_ROUTER_PORT}"
+            value: "9000"
           - name: KIE_SERVER_ROUTER_PROTOCOL
             value: "${KIE_SERVER_ROUTER_PROTOCOL}"
           - name: KIE_SERVER_PERSISTENCE_DS


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Thanks for submitting your Pull Request!

Addresses https://issues.jboss.org/browse/RHPAM-1119

Removes the possibility to configure the listening port for the smart router whereas it is still possible to configure it in the other templates where the kie server needs to connect to an external smart router instance
