### PR TITLE
[RHPAM-1166] Correct maven credentials parameter as optional

### DIFF
--- a/templates/rhpam70-authoring-ha.yaml
+++ b/templates/rhpam70-authoring-ha.yaml
@@ -288,11 +288,11 @@ parameters:
   example: http://nexus.nexus-project.svc.cluster.local:8081/nexus/content/groups/public/
   required: false
 - displayName: Maven repository username
-  description: Username to access the Maven repository.
+  description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
   required: false
 - displayName: Maven repository password
-  description: Password to access the Maven repository.
+  description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
 - displayName: Username for the Maven service hosted by Business Central

--- a/templates/rhpam70-authoring.yaml
+++ b/templates/rhpam70-authoring.yaml
@@ -192,11 +192,11 @@ parameters:
   example: http://nexus.nexus-project.svc.cluster.local:8081/nexus/content/groups/public/
   required: false
 - displayName: Maven repository username
-  description: Username to access the Maven repository.
+  description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
   required: false
 - displayName: Maven repository password
-  description: Password to access the Maven repository.
+  description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
 - displayName: Username for the Maven service hosted by Business Central

--- a/templates/rhpam70-kieserver-mysql.yaml
+++ b/templates/rhpam70-kieserver-mysql.yaml
@@ -28,11 +28,11 @@ parameters:
 - displayName: Maven repository username
   description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
-  required: true
+  required: false
 - displayName: Maven repository password
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
-  required: true
+  required: false
 - displayName: EAP Admin User
   description: EAP administrator username
   name: ADMIN_USERNAME

--- a/templates/rhpam70-kieserver-postgresql.yaml
+++ b/templates/rhpam70-kieserver-postgresql.yaml
@@ -28,11 +28,11 @@ parameters:
 - displayName: Maven repository username
   description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
-  required: true
+  required: false
 - displayName: Maven repository password
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
-  required: true
+  required: false
 - displayName: EAP Admin User
   description: EAP administrator username
   name: ADMIN_USERNAME

--- a/templates/rhpam70-prod-immutable-kieserver.yaml
+++ b/templates/rhpam70-prod-immutable-kieserver.yaml
@@ -223,22 +223,18 @@ parameters:
 - displayName: Maven mirror URL
   description: Maven mirror to use for S2I builds
   name: MAVEN_MIRROR_URL
-  value: ''
   required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository.
   name: MAVEN_REPO_URL
-  value: ''
   required: false
 - displayName: Maven repository username
-  description: Username to access the Maven repository.
+  description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
-  value: ''
   required: false
 - displayName: Maven repository password
-  description: Password to access the Maven repository.
+  description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
-  value: ''
   required: false
 - description: List of directories from which archives will be copied into the deployment folder. If unspecified, all archives in /target will be copied.
   name: ARTIFACT_DIR

--- a/templates/rhpam70-prod.yaml
+++ b/templates/rhpam70-prod.yaml
@@ -28,11 +28,11 @@ parameters:
 - displayName: Maven repository username
   description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
-  required: true
+  required: false
 - displayName: Maven repository password
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
-  required: true
+  required: false
 - displayName: EAP Admin User
   description: EAP administrator username
   name: ADMIN_USERNAME

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -26,13 +26,13 @@ parameters:
   example: http://nexus.nexus-project.svc.cluster.local:8081/nexus/content/groups/public/
   required: true
 - displayName: Maven repository username
-  description: Username to access the Maven repository.
+  description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
-  required: true
+  required: false
 - displayName: Maven repository password
-  description: Password to access the Maven repository.
+  description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
-  required: true
+  required: false
 - displayName: EAP Admin User
   description: EAP administrator username
   name: ADMIN_USERNAME

--- a/templates/rhpam70-trial-ephemeral.yaml
+++ b/templates/rhpam70-trial-ephemeral.yaml
@@ -101,7 +101,7 @@ parameters:
   example: http://nexus.nexus-project.svc.cluster.local:8081/nexus/content/groups/public/
   required: false
 - displayName: Maven repository username
-  description: Username to access the Maven repository.
+  description: Username to access the Maven repository, if required.
   name: MAVEN_REPO_USERNAME
   required: false
 - displayName: Maven repository password


### PR DESCRIPTION
[RHPAM-1166] Correct maven credentials parameter as optional and consistent description to indicate as such

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
