### PR TITLE
[RHPAM-1140] remove tx_isolation var

### DIFF
--- a/templates/rhpam70-authoring-ha.yaml
+++ b/templates/rhpam70-authoring-ha.yaml
@@ -838,8 +838,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
           - name: DROOLS_SERVER_FILTER_CLASSES
             value: "${DROOLS_SERVER_FILTER_CLASSES}"
           - name: KIE_ADMIN_PWD

--- a/templates/rhpam70-kieserver-externaldb.yaml
+++ b/templates/rhpam70-kieserver-externaldb.yaml
@@ -479,8 +479,6 @@ objects:
 ## External database driver settings END
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
           - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
             value: "${TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL}"
           - name: HTTPS_KEYSTORE_DIR

--- a/templates/rhpam70-kieserver-mysql.yaml
+++ b/templates/rhpam70-kieserver-mysql.yaml
@@ -464,8 +464,6 @@ objects:
             value: "RHPAM"
           - name: RHPAM_JNDI
             value: "${KIE_SERVER_PERSISTENCE_DS}"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
 ## MySQL driver settings BEGIN
           - name: RHPAM_DATABASE
             value: "${KIE_SERVER_MYSQL_DB}"

--- a/templates/rhpam70-kieserver-postgresql.yaml
+++ b/templates/rhpam70-kieserver-postgresql.yaml
@@ -488,8 +488,6 @@ objects:
             value: "true"
           - name: RHPAM_JNDI
             value: "${KIE_SERVER_PERSISTENCE_DS}"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
           - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
             value: "${TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL}"
           - name: HTTPS_KEYSTORE_DIR

--- a/templates/rhpam70-prod-immutable-kieserver.yaml
+++ b/templates/rhpam70-prod-immutable-kieserver.yaml
@@ -532,8 +532,6 @@ objects:
             value: "postgresql"
           - name: KIE_SERVER_PERSISTENCE_DIALECT
             value: "org.hibernate.dialect.PostgreSQLDialect"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
           - name: RHPAM_USERNAME
             value: "${KIE_SERVER_POSTGRESQL_USER}"
           - name: RHPAM_PASSWORD

--- a/templates/rhpam70-prod.yaml
+++ b/templates/rhpam70-prod.yaml
@@ -943,8 +943,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
 ## PostgreSQL driver settings 1 BEGIN
           - name: RHPAM_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"
@@ -1189,8 +1187,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
 ## PostgreSQL driver settings 2 BEGIN
           - name: RHPAM_DATABASE
             value: "${KIE_SERVER_POSTGRESQL_DB}"

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -944,8 +944,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
 ## PostgreSQL driver settings 1 BEGIN
           - name: RHPAM_DRIVER
             value: "postgresql"
@@ -1190,8 +1188,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_TX_ISOLATION
-            value: "TRANSACTION_READ_COMMITTED"
 ## PostgreSQL driver settings 2 BEGIN
           - name: RHPAM_DRIVER
             value: "postgresql"


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fixes https://issues.jboss.org/browse/RHPAM-1140 by removing the TX_ISOLATION env variable as it is defined in the scripts with a default value
https://github.com/jboss-container-images/jboss-kie-modules/blob/7.0.x/os.bpmsuite.executionserver/added/launch/bpmsuite-executionserver.sh#L111