### PR TITLE
[RHPAM-1092] Provide support and tools for additional JDBC drivers in RHPAM/OCP

### DIFF
--- a/templates/contrib/jdbc/README.md
+++ b/templates/contrib/jdbc/README.md
@@ -1,0 +1,41 @@
+# Build JDBC Driver images
+
+This repository provide a common repository for building JDBC Driver images to extend existing JBoss EAP 7.1 Openshift images using S2I.
+
+Implemented driver configurations (JDBC Drivers are NOT included):
+
+| Database  | DB Version         | JDBC Driver                                   |
+|-----------|--------------------|-----------------------------------------------|
+| IBM DB2   | 10.5               | db2jcc4-10.5.jar                              |
+| Derby     | 10.12.1.1          | derby-10.12.1.1.jar, derbyclient-10.12.1.1.jar|
+| MariaDB   | 10.2               | mariadb-java-client-2.2.5.jar                 |
+| MS SQL    | 2016               | sqljdbc4-4.0.jar                              |
+| Oracle DB | 12c R1, 12c R1 RAC | ojdbc7-12.1.0.1.jar                           |
+| Sybase    | 16.0               | jconn4-16.0_PL05.jar                          |
+
+## Build a driver image of your choice
+
+### Drivers publicly available
+
+If a driver can be publicly downloaded it has a default value for the ARTIFACT_MVN_REPO argument
+
+```bash
+# Build mariadb using a tag with the version
+$ docker build -f mariadb-driver-image/Dockerfile -t mariadb-driver-image:12.2 .
+```
+
+### Drivers not publicly available
+
+If a driver cannot be publicly downloaded it is required to provide a value for the ARTIFACT_MVN_REPO argument that might point to a local file or a private Maven repository
+
+```bash
+# Local path. e.g. ./drivers/com/sybase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar
+$ docker build -f sybase-driver-image/Dockerfile --build-args ARTIFACT_MVN_REPO=drivers -t sybase-driver-image:16.0_PL05 .
+
+# Private Maven Repository
+$ docker build sybase-driver-image --build-args ARTIFACT_MVN_REPO=https://mvn-repo.example.com/nexus/content/groups/public -t sybase-driver-image:16.0_PL05 .
+```
+
+## The build.sh script
+
+The `build.sh` script is customized for Red Hat Process Automation Manager (RHPAM) KIE Execution Server

--- a/templates/contrib/jdbc/build.sh
+++ b/templates/contrib/jdbc/build.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+
+set -ueo pipefail
+
+if [ -n "${DEBUG:-}" ] ; then
+    set -x
+fi
+
+function print_help() {
+    echo "----------------------------------------------------------"
+    echo "Builds and pushes JDBC Driver images to a docker registry. This has to be executed from a folder containing a Dockerfile"
+    echo ""
+    echo "Usage: "
+    echo "   ../build.sh [--registry=myregistry.example.com:5000] [--artifact-repo=https://myrepo.example.com/maven/public]"
+    echo "Options:"
+    echo "   Available driver images to build: db2,derby,mssql,oracle,mariadb,sybase"
+    echo "   --registry         Specifies the docker registry to use for tagging and pushing. Defaults to docker-registry.default.svc:5000"
+    echo "   --artifact-repo    Specifies the Maven repository where the jdbc drivers are available. Oracle does not have a default value"
+    echo "   --image-tag        Specifies the tag to use when building the image. Defaults to 1.1"
+}
+
+while (($#))
+do
+    case $1 in
+        --registry=*)
+            registry=${1#*=}
+        ;;
+        --artifact-repo=*)
+            artifact_repo=${1#*=}
+        ;;
+        --image-tag=*)
+            image_tag=${1#*=}
+        ;;
+        -h)
+            print_help
+            exit 0
+        ;;
+        --help)
+            print_help
+            exit 0
+        ;;
+    esac
+shift
+done
+
+if [[ ! -f Dockerfile ]]
+then
+    echo "Error: No Dockerfile found"
+    print_help
+    exit 1
+fi
+
+current_dir=${PWD##*/}
+driver=$(echo $current_dir | cut -d '-' -f 1)
+image_tag=${image_tag:-1.1}
+
+registry=${registry:-docker-registry.default.svc:5000}
+
+function docker_login() {
+    if [[ $(oc whoami -t > /dev/null; echo $?) == 1 ]]; then
+        echo "You must be logged in"
+        exit 1
+    fi
+    docker login -u `oc whoami` -p `oc whoami -t` $registry
+}
+
+function build() {
+    local driver=$1
+    local tag=$2
+    local artifact_repo=${3:-}
+    echo Building $driver
+    if [[ -n $artifact_repo ]]
+    then
+        docker build -f $current_dir/Dockerfile . -t $tag --build-arg ARTIFACT_MVN_REPO=$artifact_repo
+    else
+        docker build -f $current_dir/Dockerfile . -t $tag
+    fi
+    echo Finished bulding $tag
+}
+
+function push() {
+    local tag=$1
+    echo Pushing $tag
+    docker push $tag
+    echo Pushed $tag
+}
+
+function create_build() {
+    local driver=$1
+    local version=$2
+    oc new-build -n openshift \
+        --name rhpam70-kieserver-$driver-openshift \
+        --image-stream=openshift/rhpam70-kieserver-openshift:$image_tag \
+        --source-image=openshift/$driver-driver-image:$version \
+        --source-image-path=/extensions:$driver-driver/ \
+        --to=rhpam70-kieserver-$driver-openshift:$image_tag \
+        -e CUSTOM_INSTALL_DIRECTORIES=$driver-driver/extensions
+}
+
+docker_login
+
+pushd ..
+
+image_name=$driver-driver-image
+version=$(grep version $current_dir/Dockerfile | awk -F"=" '{print $2}' | sed 's/"//g')
+tag=$registry/openshift/$image_name:$version
+build $image_name $tag ${artifact_repo:-}
+push $tag
+create_build $driver $version
+
+popd

--- a/templates/contrib/jdbc/db2-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/db2-driver-image/Dockerfile
@@ -1,0 +1,14 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="IBM DB2 JDBC Driver" \
+        version="10.5"
+
+ARG ARTIFACT_MVN_REPO
+
+COPY install.sh db2-driver-image/install.properties /extensions/
+COPY db2-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/com/ibm/db2/jcc/db2jcc4/10.5/db2jcc4-10.5.jar \
+    /extensions/modules/system/layers/openshift/com/ibm/main/db2jcc4.jar

--- a/templates/contrib/jdbc/db2-driver-image/install.properties
+++ b/templates/contrib/jdbc/db2-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=DB2
+
+DB2_DRIVER_NAME=ibmdb2
+DB2_DRIVER_MODULE=com.ibm
+DB2_DRIVER_CLASS=com.ibm.db2.jcc.DB2Driver
+DB2_XA_DATASOURCE_CLASS=com.ibm.db2.jdbc.DB2XADataSource

--- a/templates/contrib/jdbc/db2-driver-image/modules/system/layers/openshift/com/ibm/main/module.xml
+++ b/templates/contrib/jdbc/db2-driver-image/modules/system/layers/openshift/com/ibm/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.ibm">
+  <resources>
+    <resource-root path="db2jcc4.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/templates/contrib/jdbc/derby-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/derby-driver-image/Dockerfile
@@ -1,0 +1,17 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="Derby JDBC Driver" \
+        version="10.12.1.1"
+
+ARG ARTIFACT_MVN_REPO=https://repo1.maven.org/maven2
+
+COPY install.sh derby-driver-image/install.properties /extensions/
+COPY derby-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/org/apache/derby/derbyclient/10.12.1.1/derbyclient-10.12.1.1.jar \
+    extensions/modules/system/layers/openshift/org/apache/derby/main/derbyclient.jar
+
+ADD ${ARTIFACT_MVN_REPO}/org/apache/derby/derby/10.12.1.1/derby-10.12.1.1.jar \
+    extensions/modules/system/layers/openshift/org/apache/derby/main/derby.jar

--- a/templates/contrib/jdbc/derby-driver-image/install.properties
+++ b/templates/contrib/jdbc/derby-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=DERBY
+
+DERBY_DRIVER_NAME=derby
+DERBY_DRIVER_MODULE=org.apache.derby
+DERBY_DRIVER_CLASS=org.apache.derby.jdbc.EmbeddedDriver
+DERBY_XA_DATASOURCE_CLASS=org.apache.derby.jdbc.EmbeddedXADataSource

--- a/templates/contrib/jdbc/derby-driver-image/modules/system/layers/openshift/org/apache/derby/main/module.xml
+++ b/templates/contrib/jdbc/derby-driver-image/modules/system/layers/openshift/org/apache/derby/main/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.0" name="org.apache.derby">
+    <resources>
+        <resource-root path="derby.jar"/>
+        <resource-root path="derbyclient.jar"/>
+    </resources>
+  
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+    </dependencies>
+</module>

--- a/templates/contrib/jdbc/install.sh
+++ b/templates/contrib/jdbc/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# import the common functions for installing modules and configuring drivers
+source /usr/local/s2i/install-common.sh
+
+# should be the directory where this script is located
+injected_dir=$1
+
+# install the JDBC client module
+chmod -R ugo+rX ${injected_dir}/modules
+install_modules ${injected_dir}/modules
+
+# configure the JDBC driver in standalone-openshift.xml.  Driver is named "derby"
+configure_drivers ${injected_dir}/install.properties

--- a/templates/contrib/jdbc/mariadb-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/mariadb-driver-image/Dockerfile
@@ -1,0 +1,14 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="MariaDB JDBC Driver" \
+        version="2.2.5"
+
+ARG ARTIFACT_MVN_REPO=https://repo1.maven.org/maven2
+
+COPY install.sh mariadb-driver-image/install.properties /extensions/
+COPY mariadb-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/org/mariadb/jdbc/mariadb-java-client/2.2.5/mariadb-java-client-2.2.5.jar \
+    /extensions/modules/system/layers/openshift/org/mariadb/main/mariadb-java-client.jar

--- a/templates/contrib/jdbc/mariadb-driver-image/install.properties
+++ b/templates/contrib/jdbc/mariadb-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=MARIADB
+
+MARIADB_DRIVER_NAME=mariadb
+MARIADB_DRIVER_MODULE=org.mariadb
+MARIADB_DRIVER_CLASS=org.mariadb.jdbc.Driver
+MARIADB_XA_DATASOURCE_CLASS=org.mariadb.jdbc.MariaDbDataSource

--- a/templates/contrib/jdbc/mariadb-driver-image/modules/system/layers/openshift/org/mariadb/main/module.xml
+++ b/templates/contrib/jdbc/mariadb-driver-image/modules/system/layers/openshift/org/mariadb/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="org.mariadb">
+  <resources>
+    <resource-root path="mariadb-java-client.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/templates/contrib/jdbc/mssql-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/mssql-driver-image/Dockerfile
@@ -1,0 +1,14 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="Microsoft SQL Server JDBC Driver" \
+        version="4.0"
+
+ARG ARTIFACT_MVN_REPO=http://clojars.org/repo
+
+COPY install.sh mssql-driver-image/install.properties /extensions/
+COPY mssql-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/com/microsoft/sqlserver/sqljdbc4/4.0/sqljdbc4-4.0.jar \
+    /extensions/modules/system/layers/openshift/com/microsoft/main/sqljdbc4.jar

--- a/templates/contrib/jdbc/mssql-driver-image/install.properties
+++ b/templates/contrib/jdbc/mssql-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=MSSQL
+
+MSSQL_DRIVER_NAME=sqlserver
+MSSQL_DRIVER_MODULE=com.microsoft
+MSSQL_DRIVER_CLASS=com.microsoft.sqlserver.jdbc.SQLServerDriver
+MSSQL_XA_DATASOURCE_CLASS=com.microsoft.sqlserver.jdbc.SQLServerXADataSource

--- a/templates/contrib/jdbc/mssql-driver-image/modules/system/layers/openshift/com/microsoft/main/module.xml
+++ b/templates/contrib/jdbc/mssql-driver-image/modules/system/layers/openshift/com/microsoft/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.microsoft">
+  <resources>
+    <resource-root path="sqljdbc4.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/templates/contrib/jdbc/oracle-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/oracle-driver-image/Dockerfile
@@ -1,0 +1,15 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="Oracle JDBC Driver" \
+        version="12.1.0.1"
+
+# Provide the right value during build
+ARG ARTIFACT_MVN_REPO
+
+COPY install.sh oracle-driver-image/install.properties /extensions/
+COPY oracle-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/com/oracle/ojdbc7/12.1.0.1/ojdbc7-12.1.0.1.jar \
+    /extensions/modules/system/layers/openshift/com/oracle/main/ojdbc7.jar

--- a/templates/contrib/jdbc/oracle-driver-image/install.properties
+++ b/templates/contrib/jdbc/oracle-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=ORACLE
+
+ORACLE_DRIVER_NAME=oracle
+ORACLE_DRIVER_MODULE=com.oracle
+ORACLE_DRIVER_CLASS=oracle.jdbc.driver.OracleDriver
+ORACLE_XA_DATASOURCE_CLASS=oracle.jdbc.xa.client.OracleXADataSource

--- a/templates/contrib/jdbc/oracle-driver-image/modules/system/layers/openshift/com/oracle/main/module.xml
+++ b/templates/contrib/jdbc/oracle-driver-image/modules/system/layers/openshift/com/oracle/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.oracle">
+  <resources>
+    <resource-root path="ojdbc7.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/templates/contrib/jdbc/sybase-driver-image/Dockerfile
+++ b/templates/contrib/jdbc/sybase-driver-image/Dockerfile
@@ -1,0 +1,14 @@
+FROM scratch
+
+LABEL   maintainer="rromerom@redhat.com" \
+        name="Sybase JDBC Driver" \
+        version="16.0_PL05"
+
+ARG ARTIFACT_MVN_REPO
+
+COPY install.sh sybase-driver-image/install.properties /extensions/
+COPY sybase-driver-image/modules /extensions/modules/
+
+# Download the driver into the module folder
+ADD ${ARTIFACT_MVN_REPO}/com/sysbase/jconn4/16.0_PL05/jconn4-16.0_PL05.jar \
+    /extensions/modules/system/layers/openshift/com/sybase/main/jconn4.jar

--- a/templates/contrib/jdbc/sybase-driver-image/install.properties
+++ b/templates/contrib/jdbc/sybase-driver-image/install.properties
@@ -1,0 +1,7 @@
+#DRIVERS
+DRIVERS=SYBASE
+
+SYBASE_DRIVER_NAME=sybase
+SYBASE_DRIVER_MODULE=com.sybase
+SYBASE_DRIVER_CLASS=com.sybase.jdbc4.jdbc.SybDriver
+SYBASE_XA_DATASOURCE_CLASS=com.sybase.jdbc4.jdbc.SybXADataSource

--- a/templates/contrib/jdbc/sybase-driver-image/modules/system/layers/openshift/com/sybase/main/module.xml
+++ b/templates/contrib/jdbc/sybase-driver-image/modules/system/layers/openshift/com/sybase/main/module.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.1" name="com.sybase">
+  <resources>
+    <resource-root path="jconn4.jar"/>
+  </resources>
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="javax.transaction.api"/>
+  </dependencies>
+</module>

--- a/templates/rhpam70-authoring-ha.yaml
+++ b/templates/rhpam70-authoring-ha.yaml
@@ -277,11 +277,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -754,7 +759,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 2
     selector:
@@ -770,7 +775,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-authoring.yaml
+++ b/templates/rhpam70-authoring.yaml
@@ -181,11 +181,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -543,7 +548,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -559,7 +564,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-kieserver-externaldb.yaml
+++ b/templates/rhpam70-kieserver-externaldb.yaml
@@ -78,11 +78,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Smart Router Service
   description: The service name for the optional smart router, where it can be reached, to allow smart routing
   name: KIE_SERVER_ROUTER_SERVICE
@@ -340,7 +345,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -356,7 +361,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-kieserver-mysql.yaml
+++ b/templates/rhpam70-kieserver-mysql.yaml
@@ -78,11 +78,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Smart Router Service
   description: The service name for the optional smart router, where it can be reached, to allow smart routing
   name: KIE_SERVER_ROUTER_SERVICE
@@ -345,7 +350,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -361,7 +366,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-kieserver-postgresql.yaml
+++ b/templates/rhpam70-kieserver-postgresql.yaml
@@ -78,11 +78,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Smart Router Service
   description: The service name for the optional smart router, where it can be reached, to allow smart routing
   name: KIE_SERVER_ROUTER_SERVICE
@@ -349,7 +354,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -365,7 +370,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-prod-immutable-kieserver.yaml
+++ b/templates/rhpam70-prod-immutable-kieserver.yaml
@@ -66,11 +66,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: KIE Server Monitor User
   description: KIE server monitor username, for optional use of the business-central-monitor (Sets the org.kie.server.controller.user system property)
   name: KIE_SERVER_MONITOR_USER
@@ -383,7 +388,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     output:
       to:
         kind: ImageStreamTag

--- a/templates/rhpam70-prod.yaml
+++ b/templates/rhpam70-prod.yaml
@@ -74,11 +74,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Smart Router Custom http Route Hostname
   description: Custom hostname for http service route.  Leave blank for default hostname, e.g. <application-name>-smartrouter-<project>.<default-domain-suffix>'
   name: SMART_ROUTER_HOSTNAME_HTTP
@@ -836,7 +841,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 3
     selector:
@@ -852,7 +857,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver-1"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:
@@ -1082,7 +1087,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 3
     selector:
@@ -1098,7 +1103,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver-2"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-sit.yaml
+++ b/templates/rhpam70-sit.yaml
@@ -74,11 +74,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: Smart Router Custom http Route Hostname
   description: Custom hostname for http service route.  Leave blank for default hostname, e.g. <application-name>-smartrouter-<project>.<default-domain-suffix>'
   name: SMART_ROUTER_HOSTNAME_HTTP
@@ -835,7 +840,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -851,7 +856,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver-1"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:
@@ -1081,7 +1086,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -1097,7 +1102,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver-2"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:

--- a/templates/rhpam70-trial-ephemeral.yaml
+++ b/templates/rhpam70-trial-ephemeral.yaml
@@ -85,11 +85,16 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: KIE Server ImageStream Name
+  description: The name of the image stream to use for KIE Execution Server. Default is "rhpam70-kieserver-openshift".
+  name: KIE_SERVER_IMAGE_STREAM_NAME
+  value: "rhpam70-kieserver-openshift"
+  required: true
 - displayName: ImageStream Tag
   description: A named pointer to an image in an image stream. Default is "1.1".
   name: IMAGE_STREAM_TAG
   value: "1.1"
-  required: false
+  required: true
 - displayName: KIE Server Container Deployment
   description: 'KIE Server Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2'
   name: KIE_SERVER_CONTAINER_DEPLOYMENT
@@ -367,7 +372,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: "rhpam70-kieserver-openshift:${IMAGE_STREAM_TAG}"
+          name: "${KIE_SERVER_IMAGE_STREAM_NAME}:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -383,7 +388,7 @@ objects:
         terminationGracePeriodSeconds: 60
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
-          image: rhpam70-kieserver-openshift
+          image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fixes https://issues.jboss.org/browse/RHPAM-1092

* Added support script to help building JDBC Driver images and the extended KIE Server image easily.
* Templates have been adapted to allow specifying the KIE Server image name in case a generated image is preferred.