### PR TITLE
[RHPAM-1092] KIE_SERVER_EXTERNALDB_URL cannot be mandatory

### DIFF
--- a/templates/rhpam70-kieserver-externaldb.yaml
+++ b/templates/rhpam70-kieserver-externaldb.yaml
@@ -167,7 +167,7 @@ parameters:
   description: KIE execution server external database JDBC URL
   name: KIE_SERVER_EXTERNALDB_URL
   example: "jdbc:mysql://127.0.0.1:3306/rhpam"
-  required: true
+  required: false
 - displayName: KIE Server External Database Dialect
   description: KIE execution server external database Hibernate dialect
   name: KIE_SERVER_EXTERNALDB_DIALECT


### PR DESCRIPTION
As for some databases (DB2, Sybase) we need to keep it empty.
@errantepiphany  Please take a look.

https://issues.jboss.org/browse/RHPAM-1092

Signed-off-by: Karel Suta <ksuta@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[CLOUD-XYA] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
