### PR TITLE
[RHPAM-1485] PROBE_* env vars should not exist in templates anymore

### DIFF
--- a/templates/rhpam71-authoring.yaml
+++ b/templates/rhpam71-authoring.yaml
@@ -604,10 +604,6 @@ objects:
             value: "${BUSINESS_CENTRAL_HTTPS_NAME}"
           - name: HTTPS_PASSWORD
             value: "${BUSINESS_CENTRAL_HTTPS_PASSWORD}"
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
           - name: SSO_URL
             value: "${SSO_URL}"
           - name: SSO_OPENIDCONNECT_DEPLOYMENTS

--- a/templates/rhpam71-prod-immutable-monitor.yaml
+++ b/templates/rhpam71-prod-immutable-monitor.yaml
@@ -516,10 +516,6 @@ objects:
             value: "${KIE_SERVER_MONITOR_USER}"
           - name: KIE_SERVER_CONTROLLER_PWD
             value: "${KIE_SERVER_MONITOR_PWD}"
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/businesscentral-secret-volume"
           - name: HTTPS_KEYSTORE

--- a/templates/rhpam71-prod.yaml
+++ b/templates/rhpam71-prod.yaml
@@ -821,10 +821,6 @@ objects:
             value: ${KIE_SERVER_CONTROLLER_PWD}
           - name: KIE_SERVER_CONTROLLER_USER
             value: ${KIE_SERVER_CONTROLLER_USER}
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/businesscentral-secret-volume"
           - name: HTTPS_KEYSTORE

--- a/templates/rhpam71-sit.yaml
+++ b/templates/rhpam71-sit.yaml
@@ -820,10 +820,6 @@ objects:
             value: ${KIE_SERVER_CONTROLLER_PWD}
           - name: KIE_SERVER_CONTROLLER_USER
             value: ${KIE_SERVER_CONTROLLER_USER}
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/businesscentral-secret-volume"
           - name: HTTPS_KEYSTORE

--- a/templates/rhpam71-trial-ephemeral.yaml
+++ b/templates/rhpam71-trial-ephemeral.yaml
@@ -438,10 +438,6 @@ objects:
             value: "${BUSINESS_CENTRAL_MAVEN_USERNAME}"
           - name: KIE_MAVEN_PWD
             value: "${DEFAULT_PASSWORD}"
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
           - name: SSO_URL
             value: "${SSO_URL}"
           - name: SSO_OPENIDCONNECT_DEPLOYMENTS


### PR DESCRIPTION
[RHPAM-1485] PROBE_* env vars should not exist in templates anymore
https://issues.jboss.org/browse/RHPAM-1485

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
