### PR TITLE
[RHPAM-1491] GIT_HOOKS_DIR parameter not exposed in RHPAM templates

### DIFF
--- a/templates/rhpam71-authoring-ha.yaml
+++ b/templates/rhpam71-authoring-ha.yaml
@@ -319,6 +319,11 @@ parameters:
   from: "[a-zA-Z]{6}[0-9]{1}!"
   generate: expression
   required: true
+- displayName: Git hooks directory
+  description: The directory to use for git hooks, if required.
+  name: GIT_HOOKS_DIR
+  example: /opt/git/hooks
+  required: false
 - displayName: "Timer service data store refresh interval (in milliseconds)"
   description: "Sets refresh-interval for the EJB timer database data-store service."
   name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
@@ -801,6 +806,8 @@ objects:
             value: "${BUSINESS_CENTRAL_MAVEN_USERNAME}"
           - name: KIE_MAVEN_PWD
             value: "${BUSINESS_CENTRAL_MAVEN_PASSWORD}"
+          - name: GIT_HOOKS_DIR
+            value: "${GIT_HOOKS_DIR}"
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/businesscentral-secret-volume"
           - name: HTTPS_KEYSTORE

--- a/templates/rhpam71-authoring.yaml
+++ b/templates/rhpam71-authoring.yaml
@@ -223,6 +223,11 @@ parameters:
   from: "[a-zA-Z]{6}[0-9]{1}!"
   generate: expression
   required: true
+- displayName: Git hooks directory
+  description: The directory to use for git hooks, if required.
+  name: GIT_HOOKS_DIR
+  example: /opt/git/hooks
+  required: false
 - displayName: Business Central Volume Capacity
   description: Size of the persistent storage for Business Central's runtime data.
   name: BUSINESS_CENTRAL_VOLUME_CAPACITY
@@ -612,6 +617,8 @@ objects:
             value: "${BUSINESS_CENTRAL_MAVEN_USERNAME}"
           - name: KIE_MAVEN_PWD
             value: "${BUSINESS_CENTRAL_MAVEN_PASSWORD}"
+          - name: GIT_HOOKS_DIR
+            value: "${GIT_HOOKS_DIR}"
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/businesscentral-secret-volume"
           - name: HTTPS_KEYSTORE

--- a/templates/rhpam71-trial-ephemeral.yaml
+++ b/templates/rhpam71-trial-ephemeral.yaml
@@ -129,6 +129,11 @@ parameters:
   name: BUSINESS_CENTRAL_MAVEN_USERNAME
   required: true
   value: mavenUser
+- displayName: Git hooks directory
+  description: The directory to use for git hooks, if required.
+  name: GIT_HOOKS_DIR
+  example: /opt/git/hooks
+  required: false
 - displayName: Business Central Container Memory Limit
   description: Business Central Container memory limit
   name: BUSINESS_CENTRAL_MEMORY_LIMIT
@@ -457,6 +462,8 @@ objects:
             value: "${BUSINESS_CENTRAL_MAVEN_USERNAME}"
           - name: KIE_MAVEN_PWD
             value: "${DEFAULT_PASSWORD}"
+          - name: GIT_HOOKS_DIR
+            value: "${GIT_HOOKS_DIR}"
           - name: SSO_URL
             value: "${SSO_URL}"
           - name: SSO_OPENIDCONNECT_DEPLOYMENTS


### PR DESCRIPTION
[RHPAM-1491] GIT_HOOKS_DIR parameter not exposed in RHPAM templates
https://issues.jboss.org/browse/RHPAM-1491

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
