### PR TITLE
Revert "[RHPAM-1609] - add processserver tag to pam templates to get it corre…"

### DIFF
--- a/templates/rhpam71-authoring-ha.yaml
+++ b/templates/rhpam71-authoring-ha.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,authoring,ha
+    tags: rhpam,jboss,authoring,ha
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 authoring environment (HA, persistent, with https)
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-authoring.yaml
+++ b/templates/rhpam71-authoring.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,authoring
+    tags: rhpam,jboss,authoring
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 authoring environment (non-HA, persistent, with https)
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-kieserver-externaldb.yaml
+++ b/templates/rhpam71-kieserver-externaldb.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,kieserver,externaldb
+    tags: rhpam,jboss,kieserver,externaldb
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 managed KIE Server with an external database
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-kieserver-mysql.yaml
+++ b/templates/rhpam71-kieserver-mysql.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,kieserver,mysql
+    tags: rhpam,jboss,kieserver,mysql
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 managed KIE Server with a MySQL database
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-kieserver-postgresql.yaml
+++ b/templates/rhpam71-kieserver-postgresql.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,kieserver,postgresql
+    tags: rhpam,jboss,kieserver,postgresql
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 managed KIE Server with a PostgreSQL database
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-prod-immutable-kieserver.yaml
+++ b/templates/rhpam71-prod-immutable-kieserver.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,kieserver,immutable,s2i
+    tags: rhpam,jboss,kieserver,immutable,s2i
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 immutable production environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-prod-immutable-monitor.yaml
+++ b/templates/rhpam71-prod-immutable-monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,kieserver,immutable,s2i,monitor
+    tags: rhpam,jboss,kieserver,immutable,s2i,monitor
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 production monitoring environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-prod.yaml
+++ b/templates/rhpam71-prod.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,prod
+    tags: rhpam,jboss,prod
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 production environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-sit.yaml
+++ b/templates/rhpam71-sit.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,sit
+    tags: rhpam,jboss,sit
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 SIT environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhpam71-trial-ephemeral.yaml
+++ b/templates/rhpam71-trial-ephemeral.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhpam,processserver,jboss,trial
+    tags: rhpam,jboss,trial
     version: "1.0"
     openshift.io/display-name: Red Hat Process Automation Manager 7.1 ephemeral trial environment
     openshift.io/provider-display-name: Red Hat, Inc.


### PR DESCRIPTION
Reverts jboss-container-images/rhpam-7-openshift-image#158

It was decided that we won't include this in 7.1.0, so reverting on the 7.1.x branch.