### PR TITLE
[KIECLOUD-35] Smart router OpenShift image fails to start

### DIFF
--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -80,6 +80,7 @@ modules:
           - name: dynamic-resources
           - name: java-alternatives
           - name: os-java-run
+          - name: os-logging
           - name: jboss-kie-smartrouter
 packages:
       repositories:


### PR DESCRIPTION
[KIECLOUD-35] Smart router OpenShift image fails to start
https://issues.jboss.org/browse/KIECLOUD-35

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
