### PR TITLE
[RHPAM-1717] Update default vaule of PostgreSQL ImageStream Tag in Op…

### DIFF
--- a/templates/docs/rhpam72-kieserver-postgresql.adoc
+++ b/templates/docs/rhpam72-kieserver-postgresql.adoc
@@ -52,7 +52,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`KIE_SERVER_POSTGRESQL_PWD` | -- | KIE server PostgreSQL database password | -- | False
 |`KIE_SERVER_POSTGRESQL_DB` | -- | KIE server PostgreSQL database name | rhpam7 | False
 |`POSTGRESQL_IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStream for the PostgreSQL image is installed. The ImageStream is already installed in the openshift namespace. You should only need to modify this if you've installed the ImageStream in a different namespace/project. Default is "openshift". | openshift | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6". | 9.6 | False
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10". | 10 | False
 |`POSTGRESQL_MAX_PREPARED_TRANSACTIONS` | `POSTGRESQL_MAX_PREPARED_TRANSACTIONS` | Allows the PostgreSQL to handle XA transactions. | 100 | True
 |`DB_VOLUME_CAPACITY` | -- | Size of persistent storage for database volume. | 1Gi | True
 |`DROOLS_SERVER_FILTER_CLASSES` | `DROOLS_SERVER_FILTER_CLASSES` | KIE server class filtering (Sets the org.drools.server.filter.classes system property) | true | False

--- a/templates/docs/rhpam72-prod-immutable-kieserver.adoc
+++ b/templates/docs/rhpam72-prod-immutable-kieserver.adoc
@@ -40,7 +40,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`KIE_SERVER_ROUTER_PROTOCOL` | `KIE_SERVER_ROUTER_PROTOCOL` | KIE server router protocol (Used to build the org.kie.server.router.url.external property) | `${KIE_SERVER_ROUTER_PROTOCOL}` | False
 |`KIE_SERVER_PERSISTENCE_DS` | `KIE_SERVER_PERSISTENCE_DS` | KIE server persistence datasource (Sets the org.kie.server.persistence.ds system property) | java:/jboss/datasources/rhpam | False
 |`POSTGRESQL_IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStream for the PostgreSQL image is installed. The ImageStream is already installed in the openshift namespace. You should only need to modify this if you've installed the ImageStream in a different namespace/project. Default is "openshift". | openshift | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6". | 9.6 | False
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10". | 10 | False
 |`KIE_SERVER_POSTGRESQL_USER` | `POSTGRESQL_USER` | KIE server PostgreSQL database username | rhpam | False
 |`KIE_SERVER_POSTGRESQL_PWD` | -- | KIE server PostgreSQL database password | -- | False
 |`KIE_SERVER_POSTGRESQL_DB` | -- | KIE server PostgreSQL database name | rhpam7 | False

--- a/templates/docs/rhpam72-prod.adoc
+++ b/templates/docs/rhpam72-prod.adoc
@@ -47,7 +47,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`KIE_SERVER_CONTROLLER_TOKEN` | `KIE_SERVER_CONTROLLER_TOKEN` | KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property) | `${KIE_SERVER_CONTROLLER_TOKEN}` | False
 |`KIE_SERVER_PERSISTENCE_DS` | `KIE_SERVER_PERSISTENCE_DS` | KIE server persistence datasource (Sets the org.kie.server.persistence.ds system property) | java:/jboss/datasources/rhpam | False
 |`POSTGRESQL_IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStream for the PostgreSQL image is installed. The ImageStream is already installed in the openshift namespace. You should only need to modify this if you've installed the ImageStream in a different namespace/project. Default is "openshift". | openshift | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6". | 9.6 | False
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10". | 10 | False
 |`KIE_SERVER_POSTGRESQL_USER` | `POSTGRESQL_USER` | KIE server PostgreSQL database username | rhpam | False
 |`KIE_SERVER_POSTGRESQL_PWD` | -- | KIE server PostgreSQL database password | -- | False
 |`KIE_SERVER_POSTGRESQL_DB` | -- | KIE server PostgreSQL database name | rhpam7 | False

--- a/templates/docs/rhpam72-sit.adoc
+++ b/templates/docs/rhpam72-sit.adoc
@@ -47,7 +47,7 @@ https://docs.openshift.org/latest/architecture/core_concepts/templates.html#para
 |`KIE_SERVER_CONTROLLER_TOKEN` | `KIE_SERVER_CONTROLLER_TOKEN` | KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property) | `${KIE_SERVER_CONTROLLER_TOKEN}` | False
 |`KIE_SERVER_PERSISTENCE_DS` | `KIE_SERVER_PERSISTENCE_DS` | KIE server persistence datasource (Sets the org.kie.server.persistence.ds system property) | java:/jboss/datasources/rhpam | False
 |`POSTGRESQL_IMAGE_STREAM_NAMESPACE` | -- | Namespace in which the ImageStream for the PostgreSQL image is installed. The ImageStream is already installed in the openshift namespace. You should only need to modify this if you've installed the ImageStream in a different namespace/project. Default is "openshift". | openshift | False
-|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6". | 9.6 | False
+|`POSTGRESQL_IMAGE_STREAM_TAG` | -- | The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10". | 10 | False
 |`KIE_SERVER_POSTGRESQL_USER` | `POSTGRESQL_USER` | KIE server PostgreSQL database username | rhpam | False
 |`KIE_SERVER_POSTGRESQL_PWD` | -- | KIE server PostgreSQL database password | -- | False
 |`KIE_SERVER_POSTGRESQL_DB` | -- | KIE server PostgreSQL database name | rhpam7 | False

--- a/templates/rhpam72-kieserver-postgresql.yaml
+++ b/templates/rhpam72-kieserver-postgresql.yaml
@@ -182,9 +182,9 @@ parameters:
   value: "openshift"
   required: false
 - displayName: PostgreSQL ImageStream Tag
-  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6".
+  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10".
   name: POSTGRESQL_IMAGE_STREAM_TAG
-  value: "9.6"
+  value: "10"
   required: false
 - displayName: PostgreSQL Database max prepared connections
   description: Allows the PostgreSQL to handle XA transactions.

--- a/templates/rhpam72-prod-immutable-kieserver.yaml
+++ b/templates/rhpam72-prod-immutable-kieserver.yaml
@@ -123,9 +123,9 @@ parameters:
   value: "openshift"
   required: false
 - displayName: PostgreSQL ImageStream Tag
-  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6".
+  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10".
   name: POSTGRESQL_IMAGE_STREAM_TAG
-  value: "9.6"
+  value: "10"
   required: false
 - displayName: KIE Server PostgreSQL Database User
   description: KIE server PostgreSQL database username

--- a/templates/rhpam72-prod.yaml
+++ b/templates/rhpam72-prod.yaml
@@ -164,9 +164,9 @@ parameters:
   value: "openshift"
   required: false
 - displayName: PostgreSQL ImageStream Tag
-  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6".
+  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10".
   name: POSTGRESQL_IMAGE_STREAM_TAG
-  value: "9.6"
+  value: "10"
   required: false
 - displayName: KIE Server PostgreSQL Database User
   description: KIE server PostgreSQL database username


### PR DESCRIPTION
[RHPAM-1717] Update default vaule of PostgreSQL ImageStream Tag in OpenShift templates
https://issues.jboss.org/browse/RHPAM-1717

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
