### PR TITLE
[KIECLOUD-134] Enhance KieServerStateOpenShiftRepository

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -49,15 +49,15 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
 ## OpenShift Enhancement BEGIN
-    - name: KIE_CONTROLLER_OCP_ENABLED
-      example: "true"
-      description: "If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)"
-    - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+    - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
       example: "false"
       description: "If set to true, enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)"
-    - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+    - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
       example: "60000"
       description: "KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)"
+    - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+      example: "true"
+      description: "If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)"
 ## OpenShift Enhancement END
     - name: "KIE_SERVER_USER"
       example: "executionUser"

--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -49,6 +49,9 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
 ## OpenShift Enhancement BEGIN
+    - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+      example: "false"
+      description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
     - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
       example: "false"
       description: "If set to true, enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)"

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -97,6 +97,9 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
 ## OpenShift Enhancement BEGIN
+    - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+      example: "false"
+      description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
     - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
       example: "false"
       description: "If set to true, enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)"

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -97,15 +97,15 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
 ## OpenShift Enhancement BEGIN
-    - name: KIE_CONTROLLER_OCP_ENABLED
-      example: "true"
-      description: "If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)"
-    - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+    - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
       example: "false"
       description: "If set to true, enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)"
-    - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+    - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
       example: "60000"
       description: "KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)"
+    - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+      example: "true"
+      description: "If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)"
 ## OpenShift Enhancement END
     - name: "WORKBENCH_MAX_METASPACE_SIZE"
       example: "512"

--- a/templates/rhpam74-authoring-ha.yaml
+++ b/templates/rhpam74-authoring-ha.yaml
@@ -317,6 +317,11 @@ parameters:
   value: 1Gi
   required: true
 ## OpenShift Enhancement BEGIN
+- displayName: Enable KIE server global discovery [Tech Preview]
+  description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+  value: "false"
+  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
   name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
@@ -965,6 +970,8 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED}"
           - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
             value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
           - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL

--- a/templates/rhpam74-authoring-ha.yaml
+++ b/templates/rhpam74-authoring-ha.yaml
@@ -317,20 +317,20 @@ parameters:
   value: 1Gi
   required: true
 ## OpenShift Enhancement BEGIN
-- displayName: Enable OpenShift Integration
-  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
-  name: KIE_CONTROLLER_OCP_ENABLED
-  value: "false"
-  required: false
-- displayName: Prefer KIE Server OpenShift Service
+- displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
-  name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
   value: "false"
   required: false
-- displayName: KIE ServerTemplate Cache TTL
+- displayName: KIE ServerTemplate Cache TTL [Tech Preview]
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
-  name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+  name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
   value: "60000"
+  required: false
+- displayName: Enable OpenShift Integration [Tech Preview]
+  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
+  name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+  value: "false"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace
@@ -965,12 +965,12 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
-          - name: KIE_CONTROLLER_OCP_ENABLED
-            value: "${KIE_CONTROLLER_OCP_ENABLED}"
-          - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-            value: "${KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
-          - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
-            value: "${KIE_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
+          - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+            value: "${KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+            value: "${KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED}"
 ## OpenShift Enhancement END
           - name: KIE_SERVER_CONTROLLER_USER
             value: "${KIE_SERVER_CONTROLLER_USER}"

--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -187,6 +187,11 @@ parameters:
   value: 1Gi
   required: true
 ## OpenShift Enhancement BEGIN
+- displayName: Enable KIE server global discovery [Tech Preview]
+  description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+  value: "false"
+  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
   name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
@@ -657,6 +662,8 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED}"
           - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
             value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
           - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL

--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -187,20 +187,20 @@ parameters:
   value: 1Gi
   required: true
 ## OpenShift Enhancement BEGIN
-- displayName: Enable OpenShift Integration
-  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
-  name: KIE_CONTROLLER_OCP_ENABLED
-  value: "false"
-  required: false
-- displayName: Prefer KIE Server OpenShift Service
+- displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
-  name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
   value: "false"
   required: false
-- displayName: KIE ServerTemplate Cache TTL
+- displayName: KIE ServerTemplate Cache TTL [Tech Preview]
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
-  name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+  name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
   value: "60000"
+  required: false
+- displayName: Enable OpenShift Integration [Tech Preview]
+  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
+  name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+  value: "false"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace
@@ -657,12 +657,12 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
-          - name: KIE_CONTROLLER_OCP_ENABLED
-            value: "${KIE_CONTROLLER_OCP_ENABLED}"
-          - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-            value: "${KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
-          - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
-            value: "${KIE_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
+          - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+            value: "${KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+            value: "${KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED}"
 ## OpenShift Enhancement END
           - name: KIE_SERVER_CONTROLLER_USER
             value: "${KIE_SERVER_CONTROLLER_USER}"

--- a/templates/rhpam74-managed.yaml
+++ b/templates/rhpam74-managed.yaml
@@ -24,7 +24,7 @@ message: |-
               Username: ${KIE_ADMIN_USER}
               Password: ${KIE_ADMIN_PWD}
 
-          Both sets of KIE servers are configured with the username/password
+          KIE servers are configured with the username/password
 
               Username: ${KIE_SERVER_USER}
               Password: ${KIE_SERVER_PWD}
@@ -97,20 +97,20 @@ parameters:
   generate: expression
   required: false
 ## OpenShift Enhancement BEGIN
-- displayName: Enable OpenShift Integration [Tech Preview]
-  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
-  name: KIE_CONTROLLER_OCP_ENABLED
-  value: "true"
-  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
-  name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
   value: "false"
   required: false
 - displayName: KIE ServerTemplate Cache TTL [Tech Preview]
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
-  name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+  name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
   value: "60000"
+  required: false
+- displayName: Enable OpenShift Integration [Tech Preview]
+  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
+  name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+  value: "true"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace
@@ -759,12 +759,12 @@ objects:
           - name: MAVEN_REPO_PASSWORD
             value: "${MAVEN_REPO_PASSWORD}"
 ## OpenShift Enhancement BEGIN
-          - name: KIE_CONTROLLER_OCP_ENABLED
-            value: "${KIE_CONTROLLER_OCP_ENABLED}"
-          - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-            value: "${KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
-          - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
-            value: "${KIE_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
+          - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+            value: "${KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+            value: "${KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED}"
 ## OpenShift Enhancement END
           - name: KIE_SERVER_CONTROLLER_USER
             value: "${KIE_SERVER_CONTROLLER_USER}"

--- a/templates/rhpam74-managed.yaml
+++ b/templates/rhpam74-managed.yaml
@@ -97,6 +97,11 @@ parameters:
   generate: expression
   required: false
 ## OpenShift Enhancement BEGIN
+- displayName: Enable KIE server global discovery [Tech Preview]
+  description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+  value: "false"
+  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
   name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
@@ -759,6 +764,8 @@ objects:
           - name: MAVEN_REPO_PASSWORD
             value: "${MAVEN_REPO_PASSWORD}"
 ## OpenShift Enhancement BEGIN
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED}"
           - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
             value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
           - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL

--- a/templates/rhpam74-prod-immutable-monitor.yaml
+++ b/templates/rhpam74-prod-immutable-monitor.yaml
@@ -98,6 +98,11 @@ parameters:
   generate: expression
   required: false
 ## OpenShift Enhancement BEGIN
+- displayName: Enable KIE server global discovery [Tech Preview]
+  description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+  value: "false"
+  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
   name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
@@ -633,6 +638,8 @@ objects:
           - name: EXTERNAL_MAVEN_REPO_PASSWORD
             value: "${MAVEN_REPO_PASSWORD}"
 ## OpenShift Enhancement BEGIN
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED}"
           - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
             value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
           - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL

--- a/templates/rhpam74-prod-immutable-monitor.yaml
+++ b/templates/rhpam74-prod-immutable-monitor.yaml
@@ -98,20 +98,20 @@ parameters:
   generate: expression
   required: false
 ## OpenShift Enhancement BEGIN
-- displayName: Enable OpenShift Integration
-  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
-  name: KIE_CONTROLLER_OCP_ENABLED
-  value: "false"
-  required: false
-- displayName: Prefer KIE Server OpenShift Service
+- displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
-  name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
   value: "false"
   required: false
-- displayName: KIE ServerTemplate Cache TTL
+- displayName: KIE ServerTemplate Cache TTL [Tech Preview]
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
-  name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+  name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
   value: "60000"
+  required: false
+- displayName: Enable OpenShift Integration [Tech Preview]
+  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
+  name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+  value: "false"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace
@@ -633,12 +633,12 @@ objects:
           - name: EXTERNAL_MAVEN_REPO_PASSWORD
             value: "${MAVEN_REPO_PASSWORD}"
 ## OpenShift Enhancement BEGIN
-          - name: KIE_CONTROLLER_OCP_ENABLED
-            value: "${KIE_CONTROLLER_OCP_ENABLED}"
-          - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-            value: "${KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
-          - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
-            value: "${KIE_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
+          - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+            value: "${KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+            value: "${KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED}"
 ## OpenShift Enhancement END
           - name: KIE_SERVER_CONTROLLER_USER
             value: "${KIE_SERVER_MONITOR_USER}"

--- a/templates/rhpam74-trial-ephemeral.yaml
+++ b/templates/rhpam74-trial-ephemeral.yaml
@@ -119,20 +119,20 @@ parameters:
   value: ''
   required: false
 ## OpenShift Enhancement BEGIN
-- displayName: Enable OpenShift Integration
-  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
-  name: KIE_CONTROLLER_OCP_ENABLED
-  value: "false"
-  required: false
-- displayName: Prefer KIE Server OpenShift Service
+- displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
-  name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
   value: "false"
   required: false
-- displayName: KIE ServerTemplate Cache TTL
+- displayName: KIE ServerTemplate Cache TTL [Tech Preview]
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
-  name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+  name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
   value: "60000"
+  required: false
+- displayName: Enable OpenShift Integration [Tech Preview]
+  description: If set to true, turns on OpenShift integration feature (Sets the org.kie.workbench.controller.openshift.enabled system property)
+  name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+  value: "false"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace
@@ -525,12 +525,12 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
-          - name: KIE_CONTROLLER_OCP_ENABLED
-            value: "${KIE_CONTROLLER_OCP_ENABLED}"
-          - name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
-            value: "${KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
-          - name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
-            value: "${KIE_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
+          - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+            value: "${KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL}"
+          - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+            value: "${KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED}"
 ## OpenShift Enhancement END
           - name: KIE_SERVER_CONTROLLER_USER
             value: "${KIE_SERVER_CONTROLLER_USER}"

--- a/templates/rhpam74-trial-ephemeral.yaml
+++ b/templates/rhpam74-trial-ephemeral.yaml
@@ -119,6 +119,11 @@ parameters:
   value: ''
   required: false
 ## OpenShift Enhancement BEGIN
+- displayName: Enable KIE server global discovery [Tech Preview]
+  description: "If set to true, turns on KIE server global discovery feature (Sets the org.kie.server.controller.openshift.global.discovery.enabled system property)"
+  name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+  value: "false"
+  required: false
 - displayName: Prefer KIE Server OpenShift Service [Tech Preview]
   description: Enables connection to KIE Server via OpenShift internal Service endpoint (Sets the org.kie.server.controller.openshift.prefer.kieserver.service system property)
   name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
@@ -525,6 +530,8 @@ objects:
           - name: KIE_MBEANS
             value: "${KIE_MBEANS}"
 ## OpenShift Enhancement BEGIN
+          - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+            value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED}"
           - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
             value: "${KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE}"
           - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL


### PR DESCRIPTION
Adding a runtime configuration parameter in terms of system property and environment variable for enabling BC/WB KIE server global discovery.

Related JIRA
- https://issues.jboss.org/browse/KIECLOUD-134
- https://issues.jboss.org/projects/JBPM/issues/JBPM-8269

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
