### PR TITLE
[RHPAM-1952] (7.4.0 - Ready) Exception is thrown by Business central when user clicks on deployment unit

### DIFF
--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -549,6 +549,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -792,6 +793,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-kieserver-externaldb.yaml
+++ b/templates/rhpam74-kieserver-externaldb.yaml
@@ -536,6 +536,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -572,6 +573,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-kieserver-mysql.yaml
+++ b/templates/rhpam74-kieserver-mysql.yaml
@@ -510,6 +510,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -546,6 +547,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-kieserver-postgresql.yaml
+++ b/templates/rhpam74-kieserver-postgresql.yaml
@@ -515,6 +515,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -551,6 +552,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-managed.yaml
+++ b/templates/rhpam74-managed.yaml
@@ -638,6 +638,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for First KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -879,6 +880,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhpam74-prod-immutable-kieserver-amq.yaml
@@ -665,6 +665,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -767,6 +768,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-prod-immutable-kieserver.yaml
+++ b/templates/rhpam74-prod-immutable-kieserver.yaml
@@ -535,6 +535,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -623,6 +624,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:

--- a/templates/rhpam74-trial-ephemeral.yaml
+++ b/templates/rhpam74-trial-ephemeral.yaml
@@ -444,6 +444,7 @@ objects:
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
       description: Route for KIE server's http service.
+      haproxy.router.openshift.io/balance: source
   spec:
     host: "${KIE_SERVER_HOSTNAME_HTTP}"
     to:
@@ -637,6 +638,7 @@ objects:
   spec:
     strategy:
       rollingParams:
+        maxSurge: 100%
         maxUnavailable: 0
       type: Rolling
     triggers:


### PR DESCRIPTION
To resolve an intermittent issue may occur during the KIE server DC rollout due to sticky session and eager Pod termination.

Related JIRA
https://issues.jboss.org/projects/RHPAM/issues/RHPAM-1952

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
