### PR TITLE
[RHPAM-2016] Update RHPAM images to use RHEL8 (UBI) base layer

### DIFF
--- a/businesscentral-monitoring/branch-overrides.yaml
+++ b/businesscentral-monitoring/branch-overrides.yaml
@@ -13,9 +13,7 @@ modules:
                   ref: sprint-35
           - name: jboss-eap-modules
             git:
-                  # TODO: revert to "jboss-container-images" after this PR merges: https://github.com/jboss-container-images/jboss-eap-modules/pull/84
-                # url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  url: https://github.com/luck3y/jboss-eap-modules.git
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   # TODO: replace with GA tag when available
                   ref: 7.2.x-openjdk11
           - name: jboss-eap-7-image

--- a/businesscentral/branch-overrides.yaml
+++ b/businesscentral/branch-overrides.yaml
@@ -13,9 +13,7 @@ modules:
                   ref: sprint-35
           - name: jboss-eap-modules
             git:
-                  # TODO: revert to "jboss-container-images" after this PR merges: https://github.com/jboss-container-images/jboss-eap-modules/pull/84
-                # url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  url: https://github.com/luck3y/jboss-eap-modules.git
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   # TODO: replace with GA tag when available
                   ref: 7.2.x-openjdk11
           - name: jboss-eap-7-image

--- a/controller/branch-overrides.yaml
+++ b/controller/branch-overrides.yaml
@@ -13,9 +13,7 @@ modules:
                   ref: sprint-35
           - name: jboss-eap-modules
             git:
-                  # TODO: revert to "jboss-container-images" after this PR merges: https://github.com/jboss-container-images/jboss-eap-modules/pull/84
-                # url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  url: https://github.com/luck3y/jboss-eap-modules.git
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   # TODO: replace with GA tag when available
                   ref: 7.2.x-openjdk11
           - name: jboss-eap-7-image

--- a/kieserver/branch-overrides.yaml
+++ b/kieserver/branch-overrides.yaml
@@ -13,9 +13,7 @@ modules:
                   ref: sprint-35
           - name: jboss-eap-modules
             git:
-                  # TODO: revert to "jboss-container-images" after this PR merges: https://github.com/jboss-container-images/jboss-eap-modules/pull/84
-                # url: https://github.com/jboss-container-images/jboss-eap-modules.git
-                  url: https://github.com/luck3y/jboss-eap-modules.git
+                  url: https://github.com/jboss-container-images/jboss-eap-modules.git
                   # TODO: replace with GA tag when available
                   ref: 7.2.x-openjdk11
           - name: jboss-eap-7-image


### PR DESCRIPTION
[RHPAM-2016] Update RHPAM images to use RHEL8 (UBI) base layer
https://issues.jboss.org/browse/RHPAM-2016

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
