### PR TITLE
[RHPAM-2125] - Adding support for H2 Mixed Mode connection

### DIFF
--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -836,7 +836,7 @@ objects:
             readOnly: true
 ## H2 volume mount BEGIN
           - name: "${APPLICATION_NAME}-h2-pvol"
-            mountPath: "/opt/eap/standalone/data"
+            mountPath: "/opt/kie/data"
 ## H2 volume mount END
           livenessProbe:
             httpGet:
@@ -883,7 +883,7 @@ objects:
           - name: RHPAM_PASSWORD
             value: "${KIE_SERVER_H2_PWD}"
           - name: RHPAM_XA_CONNECTION_PROPERTY_URL
-            value: "jdbc:h2:/opt/eap/standalone/data/rhpam"
+            value: "jdbc:h2:/opt/kie/data/h2/rhpam;AUTO_SERVER=TRUE"
           - name: RHPAM_SERVICE_HOST
             value: "dummy_ignored"
           - name: RHPAM_SERVICE_PORT


### PR DESCRIPTION
see:
https://issues.jboss.org/browse/RHPAM-2125

Have to create a entire new set of `EJB_TIMER` properties to configure the DS properly. The `AUTO_CONFIGURE_EJB_TIMER` is not working as intended (using the same URL from RHPAM). I should take a look into it tomorrow and could update this PR, removing the EJB_TIMER variables set.

@errantepiphany could you review, please? I should probably open a new JIRA for the AUTO_CONFIGURE_EJB_TIMER issue. If we have the time to look into it in this sprint, both JIRAs will be updated, otherwise I think this should do for the H2 database problem.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
