### PR TITLE
[RHPAM-2008] HTTP 503 error is shown in Monitoring [KIECLOUD-227] OpenShiftStartupStrategy in S2I amq template creates two configMaps and Kie Server is not deployed

### DIFF
--- a/templates/rhpam74-authoring-ha.yaml
+++ b/templates/rhpam74-authoring-ha.yaml
@@ -1212,11 +1212,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-rhpamsvc"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -1253,6 +1264,8 @@ objects:
             containerPort: 8443
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${APPLICATION_NAME}-rhpamcentr"
           - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
             value: "${TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL}"
           - name: DATASOURCES

--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -822,11 +822,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-rhpamsvc"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -867,6 +878,8 @@ objects:
             containerPort: 8443
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${APPLICATION_NAME}-rhpamcentr"
           - name: DATASOURCES
             value: "RHPAM"
           - name: RHPAM_DATABASE

--- a/templates/rhpam74-kieserver-externaldb.yaml
+++ b/templates/rhpam74-kieserver-externaldb.yaml
@@ -58,9 +58,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional business central, where it can be reached, to allow service lookups (for maven repo usage), if required.
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -632,11 +632,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-kieserver"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -676,6 +687,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -713,7 +726,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-kieserver-mysql.yaml
+++ b/templates/rhpam74-kieserver-mysql.yaml
@@ -58,9 +58,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional business central, where it can be reached, to allow service lookups (for maven repo usage), if required
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -539,11 +539,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-kieserver"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -583,6 +594,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -620,7 +633,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-kieserver-postgresql.yaml
+++ b/templates/rhpam74-kieserver-postgresql.yaml
@@ -58,9 +58,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional business central, where it can be reached, to allow service lookups (for maven repo usage), if required.
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -544,11 +544,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-kieserver"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -588,6 +599,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -625,7 +638,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-managed.yaml
+++ b/templates/rhpam74-managed.yaml
@@ -64,10 +64,10 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional Business Central, where it can be reached, to allow service lookups (for maven repo usage), if required
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
-  example: "myapp-rhpamcentr"
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
+  example: "myapp-rhpamcentrmon"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
   description: Username to access the Maven service hosted by Business Central inside EAP.
@@ -909,11 +909,22 @@ objects:
           service: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-rhpamsvc"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -953,6 +964,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${APPLICATION_NAME}-rhpamcentrmon"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -990,7 +1003,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhpam74-prod-immutable-kieserver-amq.yaml
@@ -227,9 +227,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional business central, where it can be reached, to allow service lookups (for maven repo usage), if required
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -753,6 +753,7 @@ objects:
     labels:
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-kieserver"
+      services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
     annotations:
       template.alpha.openshift.io/wait-for-ready: "true"
   spec:
@@ -785,11 +786,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-kieserver"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${APPLICATION_NAME}-kieserver"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -829,6 +841,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -860,7 +874,7 @@ objects:
           - name: MAVEN_REPOS
             value: "RHPAMCENTR,EXTERNAL"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-prod-immutable-kieserver.yaml
+++ b/templates/rhpam74-prod-immutable-kieserver.yaml
@@ -237,9 +237,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional Business Central, where it can be reached, to allow service lookups (for maven repo usage), if required.
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -621,11 +621,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-kieserver"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${APPLICATION_NAME}-kieserver"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -665,6 +676,8 @@ objects:
             containerPort: 8888
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD
@@ -702,7 +715,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-prod-immutable-monitor.yaml
+++ b/templates/rhpam74-prod-immutable-monitor.yaml
@@ -60,9 +60,9 @@ parameters:
   description: Password to access the Maven repository, if required.
   name: MAVEN_REPO_PASSWORD
   required: false
-- displayName: Name of the Maven service hosted by Business Central
-  description: The service name for the optional business central, where it can be reached, to allow service lookups (for maven repo usage), if required
-  name: BUSINESS_CENTRAL_MAVEN_SERVICE
+- displayName: Name of the Business Central service
+  description: The Service name for the optional Business Central, where it can be reached, to allow service lookups (for example,  maven repo usage), if required.
+  name: BUSINESS_CENTRAL_SERVICE
   example: "myapp-rhpamcentr"
   required: false
 - displayName: Username for the Maven service hosted by Business Central
@@ -617,7 +617,7 @@ objects:
           - name: RHPAMCENTR_MAVEN_REPO_ID
             value: "repo-rhpamcentr"
           - name: RHPAMCENTR_MAVEN_REPO_SERVICE
-            value: "${BUSINESS_CENTRAL_MAVEN_SERVICE}"
+            value: "${BUSINESS_CENTRAL_SERVICE}"
           - name: RHPAMCENTR_MAVEN_REPO_PATH
             value: "/maven2/"
           - name: RHPAMCENTR_MAVEN_REPO_USERNAME

--- a/templates/rhpam74-trial-ephemeral.yaml
+++ b/templates/rhpam74-trial-ephemeral.yaml
@@ -657,11 +657,22 @@ objects:
           services.server.kie.org/kie-server-id: "${APPLICATION_NAME}-kieserver"
       spec:
         serviceAccountName: "${APPLICATION_NAME}-rhpamsvc"
-        terminationGracePeriodSeconds: 60
+        terminationGracePeriodSeconds: 90
         containers:
         - name: "${APPLICATION_NAME}-kieserver"
           image: "${KIE_SERVER_IMAGE_STREAM_NAME}"
           imagePullPolicy: Always
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - /opt/eap/bin/launch/jboss-kie-kieserver-hooks.sh
           resources:
             limits:
               memory: "${KIE_SERVER_MEMORY_LIMIT}"
@@ -691,6 +702,8 @@ objects:
             containerPort: 8080
             protocol: TCP
           env:
+          - name: WORKBENCH_SERVICE_NAME
+            value: "${APPLICATION_NAME}-rhpamcentr"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD


### PR DESCRIPTION
@errantepiphany 
This PR can be reviewed but need to be merged together with the following PR.

Related PRs
https://github.com/jboss-container-images/jboss-kie-modules/pull/251

Related JIRAs
https://issues.jboss.org/projects/RHPAM/issues/RHPAM-2008


Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
