### PR TITLE
[KIECLOUD-226] - Set RHPAM_NONXA to false on authoring templates

### DIFF
--- a/templates/docs/rhpam74-authoring.adoc
+++ b/templates/docs/rhpam74-authoring.adoc
@@ -328,9 +328,8 @@ information.
 |`RHPAM_DRIVER` | -- | h2
 |`RHPAM_USERNAME` | -- | `${KIE_SERVER_H2_USER}`
 |`RHPAM_PASSWORD` | -- | `${KIE_SERVER_H2_PWD}`
+|`RHPAM_NONXA` | -- | `false`
 |`RHPAM_XA_CONNECTION_PROPERTY_URL` | -- | jdbc:h2:/opt/kie/data/h2/rhpam;AUTO_SERVER=TRUE
-|`RHPAM_SERVICE_HOST` | -- | dummy_ignored
-|`RHPAM_SERVICE_PORT` | -- | 12345
 |`KIE_SERVER_PERSISTENCE_DIALECT` | -- | org.hibernate.dialect.H2Dialect
 |`DROOLS_SERVER_FILTER_CLASSES` | KIE server class filtering (Sets the org.drools.server.filter.classes system property) | `${DROOLS_SERVER_FILTER_CLASSES}`
 |`KIE_ADMIN_USER` | KIE administrator username | `${KIE_ADMIN_USER}`

--- a/templates/rhpam74-authoring.yaml
+++ b/templates/rhpam74-authoring.yaml
@@ -882,12 +882,10 @@ objects:
             value: "${KIE_SERVER_H2_USER}"
           - name: RHPAM_PASSWORD
             value: "${KIE_SERVER_H2_PWD}"
+          - name: RHPAM_NONXA
+            value: "false"
           - name: RHPAM_XA_CONNECTION_PROPERTY_URL
             value: "jdbc:h2:/opt/kie/data/h2/rhpam;AUTO_SERVER=TRUE"
-          - name: RHPAM_SERVICE_HOST
-            value: "dummy_ignored"
-          - name: RHPAM_SERVICE_PORT
-            value: "12345"
           - name: KIE_SERVER_PERSISTENCE_DIALECT
             value: "org.hibernate.dialect.H2Dialect"
 ## H2 driver settings END


### PR DESCRIPTION
See: https://issues.jboss.org/browse/KIECLOUD-226
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
