### PR TITLE
[7.4.x][KIECLOUD-122] Adjust Kie Server immutable AMQ template to anble JMS client configur…

### DIFF
--- a/templates/rhpam74-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhpam74-prod-immutable-kieserver-amq.yaml
@@ -297,6 +297,7 @@ parameters:
   name: KIE_SERVER_JMS_AUDIT_TRANSACTED
   example: "false"
   required: false
+## Begin of AMQ configuration
 - displayName: AMQ Username
   description: "User name for standard broker user. It is required for connecting to the broker. If left empty, it will be generated."
   name: AMQ_USERNAME
@@ -324,6 +325,31 @@ parameters:
   name: AMQ_GLOBAL_MAX_SIZE
   example: 10 gb
   required: false
+- displayName: AMQ Secret Name 
+  description: The name of a secret containing AMQ SSL related files.
+  name: AMQ_SECRET
+  required: true
+  example: broker-app-secret
+- displayName: AMQ TRUSTSTORE
+  description: The name of the AMQ SSL Trust Store file.
+  name: AMQ_TRUSTSTORE
+  example: broker.ts
+  required: false
+- displayName: AMQ TRUSTSTORE PASSWORD
+  description: The password for the AMQ Trust Store.
+  name: AMQ_TRUSTSTORE_PASSWORD
+  example: changeit
+  required: false
+- displayName: AMQ KEYSTORE
+  description: The name of the AMQ keystore file.
+  name: AMQ_KEYSTORE
+  example: broker.ks
+  required: false
+- displayName: AMQ KEYSTORE PASSWORD
+  description: The password for the AMQ keystore and certificate.
+  name: AMQ_KEYSTORE_PASSWORD
+  example: changeit
+  required: false
 - displayName: AMQ Protocols
   description: "Broker protocols to configure, separated by commas. Allowed values are: `openwire`, `amqp`, `stomp` and `mqtt`. Only `openwire` is supported by EAP."
   name: AMQ_PROTOCOL
@@ -334,6 +360,15 @@ parameters:
   name: AMQ_BROKER_IMAGESTREAM_NAME
   required: true
   value: amq-broker-73-openshift:7.3
+- displayName: AMQ ImageStream Namespace
+  description: Namespace in which the ImageStreams for Red Hat AMQ images are
+    installed. These ImageStreams are normally installed in the openshift namespace.
+    You should only need to modify this if you installed the ImageStreams in a
+    different namespace/project.
+  name: AMQ_IMAGE_STREAM_NAMESPACE
+  value: openshift
+  required: true
+## End of AMQ configuration
 - displayName: RH-SSO URL
   description: RH-SSO URL
   name: SSO_URL
@@ -497,6 +532,23 @@ objects:
     name: "${APPLICATION_NAME}-kieserver"
   roleRef:
     name: edit
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: "amq-service-account"
+    labels:
+      application: "${APPLICATION_NAME}"
+- kind: RoleBinding
+  apiVersion: v1
+  metadata:
+     name: "amq-service-account-view"
+     labels:
+       application: "${APPLICATION_NAME}"
+  subjects:
+  - kind: ServiceAccount
+    name: "amq-service-account"
+  roleRef:
+    name: view
 - kind: Service
   apiVersion: v1
   spec:
@@ -559,7 +611,7 @@ objects:
   apiVersion: v1
   spec:
     ports:
-    - name: "amp-amqp"
+    - name: "amq-amqp"
       port: 5672
       targetPort: 5672
     selector:
@@ -571,6 +623,22 @@ objects:
       service: "${APPLICATION_NAME}-amq"
     annotations:
       description: "The broker's AMQP port."
+- kind: Service
+  apiVersion: v1
+  spec:
+    ports:
+      - name: "amq-amqp-ssl"
+        port: 5671
+        targetPort: 5671
+    selector:
+      deploymentConfig: "${APPLICATION_NAME}-amq"
+  metadata:
+    name: "${APPLICATION_NAME}-amq-amqp-ssl"
+    labels:
+      application: "${APPLICATION_NAME}"
+      service: "${APPLICATION_NAME}-amq"
+    annotations:
+      description: "The broker's AMQP SSL port."
 - kind: Service
   apiVersion: v1
   spec:
@@ -591,7 +659,23 @@ objects:
   apiVersion: v1
   spec:
     ports:
-    - name: "amp-stomp"
+    - name: "amq-mqtt-ssl"
+      port: 8883
+      targetPort: 8883
+    selector:
+      deploymentConfig: "${APPLICATION_NAME}-amq"
+  metadata:
+    name: "${APPLICATION_NAME}-amq-mqtt-ssl"
+    labels:
+      application: "${APPLICATION_NAME}"
+      service: "${APPLICATION_NAME}-amq"
+    annotations:
+      description: "The broker's MQTT SSL port."
+- kind: Service
+  apiVersion: v1
+  spec:
+    ports:
+    - name: "amq-stomp"
       port: 61613
       targetPort: 61613
     selector:
@@ -607,6 +691,22 @@ objects:
   apiVersion: v1
   spec:
     ports:
+      - name: "amq-stomp-ssl"
+        port: 61612
+        targetPort: 61612
+    selector:
+      deploymentConfig: "${APPLICATION_NAME}-amq"      
+  metadata:
+    name: "${APPLICATION_NAME}-amq-stomp-ssl"
+    labels:
+      application: "${APPLICATION_NAME}"
+      service: "${APPLICATION_NAME}-amq"
+    annotations:
+      description: "The broker's STOMP SSL port."
+- kind: Service
+  apiVersion: v1
+  spec:
+    ports:
     - name: "amq-tcp"
       port: 61616
       targetPort: 61616
@@ -615,13 +715,36 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-amq-tcp"
     labels:
-      application: ${APPLICATION_NAME}
+      application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-amq"
     annotations:
       description: The broker's OpenWire port.
       service.alpha.openshift.io/dependencies: '[{"name": "${APPLICATION_NAME}-amq-amqp",
         "kind": "Service"},{"name": "${APPLICATION_NAME}-amq-mqtt", "kind": "Service"},{"name":
         "${APPLICATION_NAME}-amq-stomp", "kind": "Service"}]'
+- kind: Service
+  apiVersion: v1
+  spec:
+    ports:
+      - name: "amq-tcp-ssl"
+        port: 61617
+        targetPort: 61617
+    selector:
+      deploymentConfig: "${APPLICATION_NAME}-amq"        
+  metadata:
+    name: "${APPLICATION_NAME}-amq-tcp-ssl"
+    labels:
+      application: "${APPLICATION_NAME}"
+      service: "${APPLICATION_NAME}-amq"
+    annotations:
+      description: The broker's OpenWire (SSL) port.
+      service.alpha.openshift.io/dependencies: '[{"name": "${APPLICATION_NAME}-amq-tcp", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-amqp", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-mqtt", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-stomp", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-amqp-ssl", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-mqtt-ssl", "kind": "Service"},{"name":
+        "${APPLICATION_NAME}-amq-stomp-ssl", "kind": "Service"}]'
 ## PostgreSQL service BEGIN
 - apiVersion: v1
   kind: Service
@@ -688,6 +811,8 @@ objects:
     to:
       kind: "Service"
       name: "${APPLICATION_NAME}-amq-jolokia"
+    tls:
+      termination: passthrough
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -892,8 +1017,6 @@ objects:
             value: "${KIE_SERVER_PERSISTENCE_DS}"
           - name: RHPAM_JTA
             value: "true"
-          - name: RHPAM_NONXA
-            value: "false"
 ## PostgreSQL driver settings BEGIN
           - name: RHPAM_DRIVER
             value: "postgresql"
@@ -1107,7 +1230,7 @@ objects:
     name: ${APPLICATION_NAME}-amq
     labels:
       application: ${APPLICATION_NAME}
-      service: "${APPLICATION_NAME}-kieserver"
+      service: "${APPLICATION_NAME}-amq"
     annotations:
       template.alpha.openshift.io/wait-for-ready: "true"
   spec:
@@ -1123,7 +1246,7 @@ objects:
         from:
           kind: ImageStreamTag
           name: ${AMQ_BROKER_IMAGESTREAM_NAME}
-          namespace: ${IMAGE_STREAM_NAMESPACE}
+          namespace: ${AMQ_IMAGE_STREAM_NAMESPACE}
       type: ImageChange
     - type: ConfigChange
     replicas: 1
@@ -1153,16 +1276,28 @@ objects:
             name: console-jolokia
             protocol: TCP
           - containerPort: 5672
-            name: amq-amqp
+            name: amqp
+            protocol: TCP
+          - containerPort: 5671
+            name: amqp-ssl
             protocol: TCP
           - containerPort: 1883
-            name: amq-mqtt
+            name: mqtt
+            protocol: TCP
+          - containerPort: 8883
+            name: mqtt-ssl
             protocol: TCP
           - containerPort: 61613
-            name: amq-stomp
+            name: stomp
+            protocol: TCP
+          - containerPort: 61612
+            name: stomp-ssl
             protocol: TCP
           - containerPort: 61616
-            name: amq-tcp
+            name: artemis
+            protocol: TCP
+          - containerPort: 61617
+            name: amq-tcp-ssl
             protocol: TCP
           env:
           - name: AMQ_USER
@@ -1183,6 +1318,24 @@ objects:
             value: "false"
           - name: AMQ_ANYCAST_PREFIX
           - name: AMQ_MULTICAST_PREFIX
+          - name: AMQ_KEYSTORE_TRUSTSTORE_DIR
+            value: "/etc/amq-secret-volume"
+          - name: AMQ_TRUSTSTORE
+            value: "${AMQ_TRUSTSTORE}"
+          - name: AMQ_TRUSTSTORE_PASSWORD
+            value: "${AMQ_TRUSTSTORE_PASSWORD}"
+          - name: AMQ_KEYSTORE
+            value: "${AMQ_KEYSTORE}"
+          - name: AMQ_KEYSTORE_PASSWORD
+            value: "${AMQ_KEYSTORE_PASSWORD}"
+          volumeMounts:
+          - name: broker-secret-volume
+            mountPath: "/etc/amq-secret-volume"            
+            readOnly: true
+        volumes:
+        - name: broker-secret-volume
+          secret:           
+            secretName: "${AMQ_SECRET}"
 ## PostgreSQL persistent volume claim BEGIN
 - apiVersion: v1
   kind: PersistentVolumeClaim


### PR DESCRIPTION
…ation outside of OpenShift

Template changes are inspired by [amq-broker-72-ssl template]( https://github.com/jboss-container-images/jboss-amq-7-broker-openshift-image/blob/amq-broker-72-dev/templates/amq-broker-72-ssl.yaml) and users should be able to configure their AMQ according to [AMQ documentation](https://access.redhat.com/documentation/en-us/red_hat_amq/7.2/html-single/deploying_amq_broker_on_openshift_container_platform/index#broker-ocp-tutorials-broker-ocp)

PR with tests for Kie Server with this communication is opened here: https://github.com/kiegroup/kie-cloud-tests/pull/395

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
