### PR TITLE
[KIECLOUD-122] - Enable JMS for RHDM and RHPAM images.

### DIFF
--- a/quickstarts/library-process/README.md
+++ b/quickstarts/library-process/README.md
@@ -290,5 +290,61 @@ http://eap-app-rhpam-kieserver.<your_openshift_suffix>/library?command=runRemote
 
 The password was generated during the app creation in the previous steps, look for **KIE Server Password**.
 
+
+### JMS integration outside OpenShift
+
+Remember, the certificates are required, for more information about how to configure the AMQ properties, please see:
+https://access.redhat.com/documentation/en-us/red_hat_amq/7.3/html/deploying_amq_broker_on_openshift_container_platform/configure-ssl-broker-ocp#configuring-ssl_broker-ocp
+
+This client allows you to test if your JMS setup is working properly and if you are able to perform JMS calls outside OpenShift
+by using the *library-process* quickstart and this client to interact with ActiveMQ.
+
+First of all, install this quickstart on OpenShift using the [rhpam75-prod-immutable-kieserver-amq.yaml](../../templates/rhpam75-prod-immutable-kieserver-amq.yaml)
+and do not forget to properly configure the S2i build and the AMQ parameters, mainly the credentials.
+
+
+Execute a maven install on the root directory of the library-process:
+```sh
+$pwd .../rhpam-7-openshift-image/quickstarts/library-process
+$ mvn clean install
+```
+
+After the quickstart is properly deployed on OpenShift, execute the following commands
+```bash
+$ mvn exec:java  -Dexec.args=runRemoteActiveMQExternal -Durl=myapp-amq-tcp-ssl-kieserver.apps.test.cloud \
+-Dusername=admin -Dpassword=redhat@123 \
+-Djavax.net.ssl.trustStore=/tmp/broker/client.ts \
+-Djavax.net.ssl.trustStorePassword=123456
+```
+
+Remember to update the properties above properly according your environment. Note that, the url is the exported route for the 
+${APPLICATION_NAME}-amq-tcp-ssl service, which should point to the port *61617*
+Not that, the url should be configured without protocol and port.
+
+If the setup is correct, a similar message will be printed:
+```bash
+...
+runRemoteActiveMQ, using properties: url=failover://ssl://myapp-amq-tcp-ssl-kieserver.apps.test.cloud:443
+runRemoteActiveMQ, using properties: username=admin
+runRemoteActiveMQ, using properties: password=redhat@123
+Using xml MarshallingFormat.JAXB
+Attempting 1st loan for isbn: 978-1-4000-5-80-2
+1st loan approved? true
+Attempting 2nd loan for isbn: 978-1-4000-5-80-2
+2nd loan approved? true
+Returning 1st loan for isbn: 978-1-4000-5-80-2
+1st loan return acknowledged? true
+Re-attempting 2nd loan for isbn: 978-1-4000-5-80-2
+Re-attempt of 2nd loan approved? true
+Received suggestion for book: Pride and Prejudice and Zombies (isbn: 978-1-59474-449-5)
+Attempting 3rd loan for isbn: 978-1-59474-449-5
+3rd loan approved? true
+Returning 2nd loan for isbn: 978-1-4000-5-80-2
+2nd loan return acknowledged? true
+Returning 3rd loan for isbn: 978-1-59474-449-5
+3rd loan return acknowledged? true
+...
+```
+
 #### Found an issue?
 Feel free to report it [here](https://github.com/jboss-container-images/rhpam-7-openshift-image/issues/new).

--- a/quickstarts/library-process/library-client/pom.xml
+++ b/quickstarts/library-process/library-client/pom.xml
@@ -30,6 +30,7 @@
 	</properties>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
@@ -96,16 +97,6 @@
 			<groupId>org.kie.server</groupId>
 			<artifactId>kie-server-client</artifactId>
 			<scope>compile</scope>
-			<exclusions>
-			  <exclusion>
-			    <groupId>com.sun.xml.bind</groupId>
-			    <artifactId>jaxb-core</artifactId>
-			  </exclusion>
-			  <exclusion>
-			    <groupId>com.sun.xml.bind</groupId>
-			    <artifactId>jaxb-impl</artifactId>
-			  </exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.openshift.quickstarts</groupId>
@@ -148,11 +139,11 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
-				<version>1.4.0</version>
+				<version>1.6.0</version>
 				<executions>
 					<execution>
 						<goals>
-							<goal>exec</goal>
+							<goal>java</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/templates/rhpam75-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhpam75-prod-immutable-kieserver-amq.yaml
@@ -542,23 +542,6 @@ objects:
     name: "${APPLICATION_NAME}-kieserver"
   roleRef:
     name: edit
-- kind: ServiceAccount
-  apiVersion: v1
-  metadata:
-    name: "amq-service-account"
-    labels:
-      application: "${APPLICATION_NAME}"
-- kind: RoleBinding
-  apiVersion: v1
-  metadata:
-     name: "amq-service-account-view"
-     labels:
-       application: "${APPLICATION_NAME}"
-  subjects:
-  - kind: ServiceAccount
-    name: "amq-service-account"
-  roleRef:
-    name: view
 - kind: Service
   apiVersion: v1
   spec:
@@ -821,6 +804,22 @@ objects:
     to:
       kind: "Service"
       name: "${APPLICATION_NAME}-amq-jolokia"
+    tls:
+      termination: passthrough
+- kind: Route
+  apiVersion: v1
+  id: "${APPLICATION_NAME}-amq-tcp-ssl"
+  metadata:
+    name: amq-tcp-ssl-external
+    labels:
+      application: "${APPLICATION_NAME}"
+      service: "${APPLICATION_NAME}-amq"
+    annotations:
+      description: "Route for AMQ tcp-ssl Service"
+  spec:
+    to:
+      kind: "Service"
+      name: "${APPLICATION_NAME}-amq-tcp-ssl"
     tls:
       termination: passthrough
 - kind: ImageStream
@@ -1329,7 +1328,7 @@ objects:
           - name: AMQ_GLOBAL_MAX_SIZE
             value: "${AMQ_GLOBAL_MAX_SIZE}"
           - name: AMQ_REQUIRE_LOGIN
-            value: "false"
+            value: "true"
           - name: AMQ_ANYCAST_PREFIX
           - name: AMQ_MULTICAST_PREFIX
           - name: AMQ_KEYSTORE_TRUSTSTORE_DIR


### PR DESCRIPTION
Follow up changes.
No service account is needed.
Need to expose the tcp-ssl port, 61617.
Configure the library-client to execut requests against a remote AMQ instance.

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

[KIECLOUD-122] - Enable JMS for RHDM and RHPAM images.

Follow up changes

Signed-off-by: Filippe Spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
