### PR TITLE
[RHPAM-2311] Add openshift module for proces-migration

### DIFF
--- a/process-migration/README.adoc
+++ b/process-migration/README.adoc
@@ -1,0 +1,5 @@
+# Red Hat Process Automation Manager 7 - Process Migration OpenShift container image
+
+## License
+
+See link:../LICENSE[LICENSE] file.

--- a/process-migration/branch-overrides.yaml
+++ b/process-migration/branch-overrides.yaml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+# Purpose: Branch overrides are for building the current state of the branch,
+#          along with other modules at specific reference points. Neither the
+#          branch nor the modules it references are guaranteed to be unchanging.
+#   Usage: cekit build --overrides-file branch-overrides.yaml
+
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: 0.35.1
+          - name: rhpam-7-image
+            git:
+                  url: https://github.com/jboss-container-images/rhpam-7-image.git
+                  ref: master
+          - name: jboss-kie-modules
+            git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: master

--- a/process-migration/container.yaml
+++ b/process-migration/container.yaml
@@ -1,0 +1,6 @@
+---
+platforms:
+  only:
+  - x86_64
+compose:
+  pulp_repos: true

--- a/process-migration/content_sets.yml
+++ b/process-migration/content_sets.yml
@@ -1,0 +1,16 @@
+# This is a file defining which content sets (yum repositories) are needed to
+# update content in this image. Data provided here helps determine which images
+# are vulnerable to specific CVEs. Generally you should only need to update this
+# file when:
+#    1. You start depending on a new product
+#    2. You are preparing new product release and your content sets will change
+#
+# See https://mojo.redhat.com/docs/DOC-1023066 for more information on
+# maintaining this file and the format and examples
+#
+# You should have one top level item for each architecture being built. Most
+# likely this will be x86_64 and ppc64le initially.
+---
+x86_64:
+- rhel-8-for-x86_64-baseos-rpms
+- rhel-8-for-x86_64-appstream-rpms

--- a/process-migration/image.yaml
+++ b/process-migration/image.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+
+name: "rhpam-7/rhpam76-process-migration-openshift"
+description: "Red Hat Process Automation Manager Process Migration 7.6 container image"
+version: "1.0"
+from: "ubi8-minimal:8-released"
+labels:
+    - name: "com.redhat.component"
+      value: "rhpam-7-rhpam76-process-migration-openshift-rhel8-container"
+    - name: "io.k8s.description"
+      value: "Platform for running Red Hat Process Automation Manager Process Migration"
+    - name: "io.k8s.display-name"
+      value: "Red Hat Process Automation Manager Process Migration 7.6"
+    - name: "io.openshift.expose-services"
+      value: "8080:http"
+    - name: "io.openshift.tags"
+      value: "javaee,rhpam,rhpam7"
+envs:
+    - name: "SCRIPT_DEBUG"
+      example: "true"
+      description: "If set to true, ensures that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
+    - name: JBOSS_KIE_EXTRA_CLASSPATH
+      example: "mariadb-java-client-2.4.2.jar,postgresql-42.2.6.jar"
+      description: "Comma separated list of libraries to add to the classpath. They must be accessible."
+    - name: JBOSS_KIE_EXTRA_CONFIG
+      example: "/opt/rhpam-process-migration/config-extra/pim-config.yaml"
+      description: "Path to a file including a yaml configuration file to override default Thorntail configuration and target KIE Servers"
+ports:
+    - value: 8080
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: master
+          - name: rhpam-7-image
+            git:
+                  url: https://github.com/jboss-container-images/rhpam-7-image.git
+                  ref: master
+          - name: jboss-kie-modules
+            git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: master
+      install:
+          - name: jboss.container.openjdk.jdk
+            version: "11"
+          - name: dynamic-resources
+          - name: rhpam-7-process-migration
+          - name: os-logging
+          - name: jboss-kie-process-migration
+packages:
+      content_sets_file: content_sets.yml
+      install:
+          - hostname
+osbs:
+      configuration:
+          container_file: container.yaml
+      repository:
+          name: containers/rhpam-7-process-migration-openshift
+          branch: rhba-7.6-openshift-rhel-8
+run:
+      user: 185
+      cmd:
+          - "/opt/rhpam-process-migration/openshift-launch.sh"

--- a/process-migration/tag-overrides.yaml
+++ b/process-migration/tag-overrides.yaml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+# Purpose: Tag overrides are for reliably rebuilding the image per the state of
+#          the branch at the time the tag was created, along with other modules
+#          at reliable and unchanging reference points. Useful for CVE respins.
+#          Warning: Only reliable if referenced via a tag itself!
+#   Usage: cekit build --overrides-file tag-overrides.yaml
+
+modules:
+      repositories:
+          - name: cct_module
+            git:
+                  url: https://github.com/jboss-openshift/cct_module.git
+                  ref: 0.35.1
+          - name: rhpam-7-image
+            git:
+                  url: https://github.com/jboss-container-images/rhpam-7-image.git
+                  ref: 7.6.0.GA
+          - name: jboss-kie-modules
+            git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: rhpam-7.6.0.GA


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/RHPAM-2311

Adds rhpam-7-openshift-image cekit module for building process-migration images

Depends on 
* https://github.com/jboss-container-images/jboss-kie-modules/pull/302
* https://github.com/jboss-container-images/rhpam-7-image/pull/156