### PR TITLE
[RHPAM-2354] OutOfMemoryError on Datagrid cause issues on project import indexing

### DIFF
--- a/templates/rhpam75-authoring-ha.yaml
+++ b/templates/rhpam75-authoring-ha.yaml
@@ -219,12 +219,17 @@ parameters:
 - displayName: DataGrid Image
   description: DataGrid image.
   name: DATAGRID_IMAGE
-  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.1
+  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.2
+  required: true
+- displayName: DataGrid Container CPU Limit
+  description: DataGrid Container cpu limit.
+  name: DATAGRID_CPU_LIMIT
+  value: "1000m"
   required: true
 - displayName: DataGrid Container Memory Limit
   description: DataGrid Container memory limit
   name: DATAGRID_MEMORY_LIMIT
-  value: "512Mi"
+  value: "2Gi"
   required: true
 - displayName: DataGrid Volume Capacity
   description: Size of the persistent storage for DataGrid's runtime data.
@@ -822,9 +827,10 @@ objects:
             timeoutSeconds: 10
           resources:
             limits:
+              cpu: ${DATAGRID_CPU_LIMIT}
               memory: ${DATAGRID_MEMORY_LIMIT}
             requests:
-              cpu: "0.5"
+              cpu: ${DATAGRID_CPU_LIMIT}
               memory: ${DATAGRID_MEMORY_LIMIT}
           volumeMounts:
           - mountPath: /opt/datagrid/standalone/data


### PR DESCRIPTION
[RHPAM-2354] OutOfMemoryError on Datagrid cause issues on project import indexing
https://issues.jboss.org/browse/RHPAM-2354

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
