### PR TITLE
[RHDM-1096] - Add missing environment variable for optaplanner thread pool queue size

### DIFF
--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -185,6 +185,9 @@ envs:
     - name: "PROMETHEUS_SERVER_EXT_DISABLED"
       example: "false"
       description: "If set to false, the prometheus server extension will be enabled. (Sets the org.kie.prometheus.server.ext.disabled system property)"
+    - name: "OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE"
+      example: "4"
+      description: "The default queue size is equal to the number of active CPU cores. (Sets the org.optaplanner.server.ext.thread.pool.queue.size system property)" 
 ports:
     - value: 8080
     - value: 8443


### PR DESCRIPTION
[RHDM-1096] - Add missing environment variable for optaplanner thread pool queue size

See: https://issues.jboss.org/browse/RHDM-1096

Signed-off-by: Mauricio Magnani <mmagnani@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
