### PR TITLE
[RHPAM-2634] Remote Server is lot from the controller after Kie Server scale down and scale up

### DIFF
--- a/templates/rhpam77-authoring-ha.yaml
+++ b/templates/rhpam77-authoring-ha.yaml
@@ -280,7 +280,7 @@ parameters:
 - displayName: KIE ServerTemplate Cache TTL
   description: KIE ServerTemplate Cache TTL in milliseconds. (Sets the org.kie.server.controller.template.cache.ttl system property)
   name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-  value: "60000"
+  value: "5000"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace

--- a/templates/rhpam77-authoring.yaml
+++ b/templates/rhpam77-authoring.yaml
@@ -200,7 +200,7 @@ parameters:
 - displayName: KIE ServerTemplate Cache TTL
   description: KIE ServerTemplate Cache TTL in milliseconds. (Sets the org.kie.server.controller.template.cache.ttl system property)
   name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-  value: "60000"
+  value: "5000"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace

--- a/templates/rhpam77-managed.yaml
+++ b/templates/rhpam77-managed.yaml
@@ -115,7 +115,7 @@ parameters:
 - displayName: KIE ServerTemplate Cache TTL
   description: KIE ServerTemplate Cache TTL in milliseconds. (Sets the org.kie.server.controller.template.cache.ttl system property)
   name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-  value: "60000"
+  value: "5000"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace

--- a/templates/rhpam77-prod-immutable-monitor.yaml
+++ b/templates/rhpam77-prod-immutable-monitor.yaml
@@ -111,7 +111,7 @@ parameters:
 - displayName: KIE ServerTemplate Cache TTL
   description: KIE ServerTemplate Cache TTL in milliseconds (Sets the org.kie.server.controller.template.cache.ttl system property)
   name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-  value: "60000"
+  value: "5000"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace

--- a/templates/rhpam77-trial-ephemeral.yaml
+++ b/templates/rhpam77-trial-ephemeral.yaml
@@ -132,7 +132,7 @@ parameters:
 - displayName: KIE ServerTemplate Cache TTL
   description: KIE ServerTemplate Cache TTL in milliseconds. (Sets the org.kie.server.controller.template.cache.ttl system property)
   name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-  value: "60000"
+  value: "5000"
   required: false
 ## OpenShift Enhancement END
 - displayName: ImageStream Namespace


### PR DESCRIPTION
Related JIRA link:
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2634

Related PRs
https://github.com/jboss-container-images/jboss-kie-modules/pull/346
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/411
https://github.com/kiegroup/kie-cloud-operator/pull/343

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
