### PR TITLE
[RHPAM-3273] 7.9.x Fix example for LOG_LEVEL in SmartRouter image

### DIFF
--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -75,7 +75,7 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
     - name: "LOG_LEVEL"
-      example: "INFO"
+      example: "FINE"
       description: "Java log level to apply in the logger configuration, if empty the level used will be INFO"
     - name: "LOGGER_CATEGORIES"
       example: "org.kie=FINE,org.apache=INFO,org.eclipse=INFO"

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -75,10 +75,10 @@ envs:
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
     - name: "LOG_LEVEL"
-      example: "DEBUG"
+      example: "INFO"
       description: "Java log level to apply in the logger configuration, if empty the level used will be INFO"
     - name: "LOGGER_CATEGORIES"
-      example: "LOGGER_CATEGORIES='org.kie=DEBUG,org.apache=INFO,org.eclipse=INFO'"
+      example: "org.kie=FINE,org.apache=INFO,org.eclipse=INFO"
       description: "fully qualified logger name with log level, in multiple separated by comma"
 ports:
     - value: 9000


### PR DESCRIPTION
@spolti 7.9.x cherry pick of https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/477
