### PR TITLE
[RHPAM-3326] - Defaul value for MaxMetaspaceSize in Operator overried…

### DIFF
--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -190,7 +190,7 @@ envs:
       description: "The default queue size is equal to the number of active CPU cores. (Sets the org.optaplanner.server.ext.thread.pool.queue.size system property)"
     - name: "KIE_SERVER_MAX_METASPACE_SIZE"
       example: "256"
-      description: "The maximum metaspace for the KIE Server, it will set the GC_MAX_METASPACE_SIZE, its default value is 512mb."
+      description: "The maximum metaspace size, set as integer in megabytes, for the KIE Server. This will overwrite value set by GC_MAX_METASPACE_SIZE. Default max metaspace size for KIE Server is 512mb."
 ports:
     - value: 8080
     - value: 8443

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -188,6 +188,9 @@ envs:
     - name: "OPTAPLANNER_SERVER_EXT_THREAD_POOL_QUEUE_SIZE"
       example: "4"
       description: "The default queue size is equal to the number of active CPU cores. (Sets the org.optaplanner.server.ext.thread.pool.queue.size system property)"
+    - name: "KIE_SERVER_MAX_METASPACE_SIZE"
+      example: "256"
+      description: "The maximum metaspace for the KIE Server, it will set the GC_MAX_METASPACE_SIZE, its default value is 512mb."
 ports:
     - value: 8080
     - value: 8443


### PR DESCRIPTION
…s default values set by image scripts

See: https://issues.redhat.com/browse/RHPAM-3326

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
