### PR TITLE
[KIECLOUD-614] - Application Templates still referencing the AUTH_LDA…

### DIFF
--- a/templates/rhpam713-authoring-ha.yaml
+++ b/templates/rhpam713-authoring-ha.yaml
@@ -451,11 +451,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -1039,8 +1034,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -1311,8 +1304,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-authoring.yaml
+++ b/templates/rhpam713-authoring.yaml
@@ -345,11 +345,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -706,8 +701,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -974,8 +967,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-kieserver-externaldb.yaml
+++ b/templates/rhpam713-kieserver-externaldb.yaml
@@ -357,11 +357,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -801,8 +796,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-kieserver-mysql.yaml
+++ b/templates/rhpam713-kieserver-mysql.yaml
@@ -294,11 +294,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -687,8 +682,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-kieserver-postgresql.yaml
+++ b/templates/rhpam713-kieserver-postgresql.yaml
@@ -299,11 +299,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -692,8 +687,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-managed.yaml
+++ b/templates/rhpam713-managed.yaml
@@ -380,11 +380,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -762,8 +757,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -1030,8 +1023,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhpam713-prod-immutable-kieserver-amq.yaml
@@ -435,11 +435,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -1082,8 +1077,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-prod-immutable-kieserver.yaml
+++ b/templates/rhpam713-prod-immutable-kieserver.yaml
@@ -325,11 +325,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -767,8 +762,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-prod-immutable-monitor.yaml
+++ b/templates/rhpam713-prod-immutable-monitor.yaml
@@ -274,11 +274,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -663,8 +658,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-prod.yaml
+++ b/templates/rhpam713-prod.yaml
@@ -452,11 +452,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -962,8 +957,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -1332,8 +1325,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -1672,8 +1663,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhpam713-trial-ephemeral.yaml
+++ b/templates/rhpam713-trial-ephemeral.yaml
@@ -260,11 +260,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -537,8 +532,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -734,8 +727,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN


### PR DESCRIPTION
…P_DISTINGUISHED_NAME_ATTRIBUTE env
See: https://issues.redhat.com/browse/KIECLOUD-614
Cherry-picks: https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/591

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
