### PR TITLE
[KIECLOUD-610] - Fixing formatting issue with bash code in post-configure-example quic…

### DIFF
--- a/quickstarts/post-configure-example/README.md
+++ b/quickstarts/post-configure-example/README.md
@@ -20,13 +20,14 @@ Note: This procedure can be applied to any kind of post configure actions.
 Before deployment, prepare the required files. You must have the following files:
 
 - [add-users.cli](add-users.cli): JBoss CLI Batch script, your script must be added between the commands below:
-    - ```bash
+  ```bash
   embed-server --std-out=echo --server-config=standalone-openshift.xml batch
 
-    <your jboss-cli commands>
+  <your jboss-cli commands>
 
-  run-batch quit
-    ```
+  run-batch 
+  quit
+  ```
 
 - [delayedpostconfigure.sh](delayedpostconfigure.sh): This empty file is needed until the following jira is fixed:
   https://issues.redhat.com/browse/RHPAM-3665


### PR DESCRIPTION
…kstart README

Cherry-picks: #596

Signed-off-by: Davide Salerno <dsalerno@redhat.com>
 
Issue introduced with [KIECLOUD-610](https://issues.redhat.com/browse/KIECLOUD-610)

Now it will look like

![Screenshot from 2022-01-11 18-25-13](https://user-images.githubusercontent.com/640621/149001095-852e075d-3cbd-454b-bf4a-c369f6c41f1c.png)


Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
