### PR TITLE
Jira SO-19: Remove non-groupified APIs in openshift/library templates

### DIFF
--- a/rhpam713-image-streams.yaml
+++ b/rhpam713-image-streams.yaml
@@ -1,5 +1,5 @@
 kind: ImageStreamList
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: rhpam713-image-streams
   annotations:
@@ -7,7 +7,7 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
 items:
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-businesscentral-rhel8
       annotations:
@@ -28,7 +28,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-businesscentral-monitoring-rhel8
       annotations:
@@ -49,7 +49,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-controller-rhel8
       annotations:
@@ -70,7 +70,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-dashbuilder-rhel8
       annotations:
@@ -91,7 +91,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-kieserver-rhel8
       annotations:
@@ -112,7 +112,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-smartrouter-rhel8
       annotations:
@@ -133,7 +133,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhpam-process-migration-rhel8
       annotations:

--- a/templates/process/rhpam713-authoring-ha.yaml
+++ b/templates/process/rhpam713-authoring-ha.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-authoring.yaml
+++ b/templates/process/rhpam713-authoring.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-kieserver-externaldb.yaml
+++ b/templates/process/rhpam713-kieserver-externaldb.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss
@@ -486,7 +486,7 @@ objects:
       tls:
         termination: passthrough
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: "${APPLICATION_NAME}-kieserver"
       labels:

--- a/templates/process/rhpam713-kieserver-mysql.yaml
+++ b/templates/process/rhpam713-kieserver-mysql.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-kieserver-postgresql.yaml
+++ b/templates/process/rhpam713-kieserver-postgresql.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-managed.yaml
+++ b/templates/process/rhpam713-managed.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-prod-immutable-kieserver-amq.yaml
+++ b/templates/process/rhpam713-prod-immutable-kieserver-amq.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss
@@ -759,7 +759,7 @@ objects:
       tls:
         termination: passthrough
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: "${APPLICATION_NAME}-kieserver"
       labels:

--- a/templates/process/rhpam713-prod-immutable-kieserver.yaml
+++ b/templates/process/rhpam713-prod-immutable-kieserver.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss
@@ -471,7 +471,7 @@ objects:
       tls:
         termination: passthrough
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: "${APPLICATION_NAME}-kieserver"
       labels:

--- a/templates/process/rhpam713-prod-immutable-monitor.yaml
+++ b/templates/process/rhpam713-prod-immutable-monitor.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-prod.yaml
+++ b/templates/process/rhpam713-prod.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/process/rhpam713-trial-ephemeral.yaml
+++ b/templates/process/rhpam713-trial-ephemeral.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss


### PR DESCRIPTION
Non-groupified APIs were deprecated in OCP 4.7.

This PR only handles the imagestreams/Templates which are bundled in OpenShift. If any of the other imagestreams or templates are meant to still be used, they should also be similarly updated. A complete API list is available at https://docs.openshift.com/container-platform/4.10/rest_api/index.html .

Signed-off-by: Feny Mehta <fbm3307@gmail.com>