### PR TITLE
[7.13.x] use 8.6 tag of ubi8 image for building the images

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-businesscentral-monitoring-rhel8"
 description: "Red Hat Business Central Monitoring 7.13 OpenShift container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-businesscentral-monitoring-rhel8-container"

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-businesscentral-rhel8"
 description: "Red Hat Business Central 7.13 OpenShift container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-businesscentral-rhel8-container"

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-controller-rhel8"
 description: "Red Hat Process Automation Manager Standalone Controller 7.13 container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-controller-rhel8-container"

--- a/dashbuilder/image.yaml
+++ b/dashbuilder/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-dashbuilder-rhel8"
 description: "Red Hat Process Automation Manager Standalone Dashbuilder 7.13 container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-dashbuilder-rhel8-container"

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-kieserver-rhel8"
 description: "Red Hat Process Automation Manager Kie Server 7.13 container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-kieserver-rhel8-container"

--- a/process-migration/image.yaml
+++ b/process-migration/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-process-migration-rhel8"
 description: "Red Hat Process Automation Manager Process Migration 7.13 container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-process-migration-rhel8-container"

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "rhpam-7/rhpam-smartrouter-rhel8"
 description: "Red Hat Process Automation Manager Smart Router 7.13 container image"
 version: "7.13.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "rhpam-7-smartrouter-rhel8-container"


### PR DESCRIPTION
This is required for now as latest ubi8 tag is using a RHEL 8.7 which seems to contain a bug and it is pulling an old version of nss package which is affected by a critical CVE.

Related PRs:
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/650
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/651

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
