### PR TITLE
[7.13.x-blue] use 8.6 tag of ubi8 image for building the images

### DIFF
--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-businesscentral-monitoring-rhel8"
 description: "IBM Business Central Monitoring 8.0 OpenShift container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-businesscentral-monitoring-rhel8-container"

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-businesscentral-rhel8"
 description: "IBM Business Central 8.0 OpenShift container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-businesscentral-rhel8-container"

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-controller-rhel8"
 description: "IBM Standalone Controller 8.0 container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-controller-rhel8-container"

--- a/dashbuilder/image.yaml
+++ b/dashbuilder/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-dashbuilder-rhel8"
 description: "IBM Standalone Dashbuilder 8.0 container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-dashbuilder-rhel8-container"

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-kieserver-rhel8"
 description: "IBM Kie Server 8.0 container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-kieserver-rhel8-container"

--- a/process-migration/image.yaml
+++ b/process-migration/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-process-migration-rhel8"
 description: "IBM Process Migration 8.0 container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-process-migration-rhel8-container"

--- a/smartrouter/image.yaml
+++ b/smartrouter/image.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 name: "ibm-bamoe/bamoe-smartrouter-rhel8"
 description: "IBM Smart Router 8.0 container image"
 version: "8.0.1"
-from: "registry.redhat.io/ubi8/ubi-minimal:latest"
+from: "registry.redhat.io/ubi8/ubi-minimal:8.6"
 labels:
   - name: "com.redhat.component"
     value: "ibm-bamoe-smartrouter-rhel8-container"


### PR DESCRIPTION
This is required for now as latest ubi8 tag is using a RHEL 8.7 which seems to contain a bug and it is pulling an old version of nss package which is affected by a critical CVE.

Related PRs:
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/650
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/651


Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
