### PR TITLE
[RHPAM-3709] - CVE-2021-26291 rhpam-7-businesscentral-rhel8-container…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ hs_err_pid*
 .mtj.tmp/
 my*.json
 my*.yaml
+my*.yml
 .project
 .settings/
 target

--- a/businesscentral-monitoring/branch-overrides.yaml
+++ b/businesscentral-monitoring/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -110,8 +110,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-businesscentral-monitoring
-    - name: jboss.container.maven.36.bash
-      version: "3.6"
+    - name: jboss.container.maven.38.bash
+      version: "3.8"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/businesscentral-monitoring/tag-overrides.yaml
+++ b/businesscentral-monitoring/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/businesscentral/branch-overrides.yaml
+++ b/businesscentral/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -171,8 +171,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-businesscentral
-    - name: jboss.container.maven.36.bash
-      version: "3.6"
+    - name: jboss.container.maven.38.bash
+      version: "3.8"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/businesscentral/tag-overrides.yaml
+++ b/businesscentral/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/controller/branch-overrides.yaml
+++ b/controller/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -90,8 +90,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-controller
-    - name: jboss.container.maven.36.bash
-      version: "3.6"
+    - name: jboss.container.maven.38.bash
+      version: "3.8"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/controller/tag-overrides.yaml
+++ b/controller/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/dashbuilder/branch-overrides.yaml
+++ b/dashbuilder/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/dashbuilder/tag-overrides.yaml
+++ b/dashbuilder/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/kieserver/branch-overrides.yaml
+++ b/kieserver/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -305,8 +305,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-kieserver
-    - name: jboss.container.maven.36.bash
-      version: "3.6"
+    - name: jboss.container.maven.38.bash
+      version: "3.8"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.eap.s2i.bash
     - name: jboss.container.jolokia.bash

--- a/kieserver/tag-overrides.yaml
+++ b/kieserver/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/process-migration/branch-overrides.yaml
+++ b/process-migration/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: rhpam-7-image
       git:
         url: https://github.com/jboss-container-images/rhpam-7-image.git

--- a/process-migration/tag-overrides.yaml
+++ b/process-migration/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: rhpam-7-image
       git:
         url: https://github.com/jboss-container-images/rhpam-7-image.git

--- a/smartrouter/branch-overrides.yaml
+++ b/smartrouter/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/smartrouter/tag-overrides.yaml
+++ b/smartrouter/tag-overrides.yaml
@@ -11,7 +11,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.6
+        ref: 0.39.7
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git


### PR DESCRIPTION
…: maven: Block repositories using http by default [rhpam-7]
See: https://issues.redhat.com/browse/RHPAM-3709
Cherry-picks https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/652

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
