### PR TITLE
[7.13.x-next][RHPAM-4831] Upgrade JBoss EAP to 7.4.13 on RHPAM images

### DIFF
--- a/businesscentral-monitoring/branch-overrides.yaml
+++ b/businesscentral-monitoring/branch-overrides.yaml
@@ -14,11 +14,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/businesscentral-monitoring/tag-overrides.yaml
+++ b/businesscentral-monitoring/tag-overrides.yaml
@@ -15,11 +15,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/businesscentral/branch-overrides.yaml
+++ b/businesscentral/branch-overrides.yaml
@@ -14,11 +14,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/businesscentral/tag-overrides.yaml
+++ b/businesscentral/tag-overrides.yaml
@@ -15,11 +15,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/controller/branch-overrides.yaml
+++ b/controller/branch-overrides.yaml
@@ -14,11 +14,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/controller/tag-overrides.yaml
+++ b/controller/tag-overrides.yaml
@@ -15,11 +15,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/dashbuilder/branch-overrides.yaml
+++ b/dashbuilder/branch-overrides.yaml
@@ -14,11 +14,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/dashbuilder/tag-overrides.yaml
+++ b/dashbuilder/tag-overrides.yaml
@@ -15,11 +15,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/kieserver/branch-overrides.yaml
+++ b/kieserver/branch-overrides.yaml
@@ -14,11 +14,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/kieserver/tag-overrides.yaml
+++ b/kieserver/tag-overrides.yaml
@@ -15,11 +15,11 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: jboss-eap-7-image
       git:
         url: https://github.com/jboss-container-images/jboss-eap-7-image.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: wildfly-cekit-modules
       git:
         url: https://github.com/wildfly/wildfly-cekit-modules.git

--- a/smartrouter/branch-overrides.yaml
+++ b/smartrouter/branch-overrides.yaml
@@ -14,7 +14,7 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: rhpam-7-image
       git:
         url: https://github.com/jboss-container-images/rhpam-7-image.git

--- a/smartrouter/tag-overrides.yaml
+++ b/smartrouter/tag-overrides.yaml
@@ -15,7 +15,7 @@ modules:
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git
-        ref: EAP_7412_CR3
+        ref: EAP_7413_CR1
     - name: rhpam-7-image
       git:
         url: https://github.com/jboss-container-images/rhpam-7-image.git


### PR DESCRIPTION
jboss-eap-7-image tag  EAP_7413_CR1 already includes the EAP one-off for CVE-2023-44487

Related PRs:
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/704
- https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/705

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHPAM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
