### PR TITLE
 BAMOE V8 - Upgrade Maven

### DIFF
--- a/businesscentral-monitoring/branch-overrides.yaml
+++ b/businesscentral-monitoring/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/businesscentral-monitoring/image.yaml
+++ b/businesscentral-monitoring/image.yaml
@@ -112,8 +112,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-businesscentral-monitoring
-    - name: jboss.container.maven.38.bash
-      version: "3.8"
+    - name: jboss.container.maven.39.bash
+      version: "3.9"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/businesscentral/branch-overrides.yaml
+++ b/businesscentral/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9 
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/businesscentral/image.yaml
+++ b/businesscentral/image.yaml
@@ -172,8 +172,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-businesscentral
-    - name: jboss.container.maven.38.bash
-      version: "3.8"
+    - name: jboss.container.maven.39.bash
+      version: "3.9"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/controller/branch-overrides.yaml
+++ b/controller/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -92,8 +92,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-controller
-    - name: jboss.container.maven.38.bash
-      version: "3.8"
+    - name: jboss.container.maven.39.bash
+      version: "3.9"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.jolokia.bash
     - name: jboss.eap.cd.jolokia

--- a/dashbuilder/branch-overrides.yaml
+++ b/dashbuilder/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/kieserver/branch-overrides.yaml
+++ b/kieserver/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -307,8 +307,8 @@ modules:
       version: "7.4-latest"
     - name: jboss.container.eap.setup
     - name: ibm-bamoe-8-kieserver
-    - name: jboss.container.maven.38.bash
-      version: "3.8"
+    - name: jboss.container.maven.39.bash
+      version: "3.9"
     - name: jboss.container.maven.default.bash
     - name: jboss.container.eap.s2i.bash
     - name: jboss.container.jolokia.bash

--- a/process-migration/branch-overrides.yaml
+++ b/process-migration/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: rhpam-7-image
       git:
         url: https://github.com/jboss-container-images/rhpam-7-image.git

--- a/smartrouter/branch-overrides.yaml
+++ b/smartrouter/branch-overrides.yaml
@@ -10,7 +10,7 @@ modules:
     - name: cct_module
       git:
         url: https://github.com/jboss-openshift/cct_module.git
-        ref: 0.39.8
+        ref: 0.39.9
     - name: jboss-eap-modules
       git:
         url: https://github.com/jboss-container-images/jboss-eap-modules.git


### PR DESCRIPTION
  Upgrades the Business Central image from Maven 3.8 to Maven 3.9.
  
  **Dependency**
This PR currently depends on the following cct_module branch:
```
- name: cct_module
  git:
    url: https://github.com/abhijithumbe/cct_module.git
    ref: DBACLD-240809_cc_module
```
Depends on: https://github.com/jboss-openshift/cct_module/pull/426
This personal-fork reference is temporary and is included only to allow review and image-build validation. It will be replaced with an official jboss-openshift/cct_module tag  for all images once PR#426 is merged and tag is defined.


The Business Central and kie-server image built successfully:

localhost/ibm-bamoe/bamoe-businesscentral-rhel9:8.0.9
localhost/ibm-bamoe/bamoe-businesscentral-rhel9:8.0.9

Installed Maven: Apache Maven 3.9.9 (Red Hat 3.9.9-13)
Installed RPM: maven-3.9.9-13.module+el9.8.0+24097+2b12e1e0.noarch
Enabled Maven stream:
[maven]
name=maven
stream=3.9
profiles=
state=enabled

Validated dependencies:
guava-33.3.0-5.module+el9.8.0+24097+2b12e1e0.noarch
apache-commons-io-2.16.1-9.module+el9.8.0+24097+2b12e1e0.noarch
plexus-utils-3.5.1-17.module+el9.8.0+24375+95248a69.1.noarch
